### PR TITLE
fix(chat-input): Enter sends on touch laptops, fix Edge input visibility

### DIFF
--- a/ui/src/components/ChatInput.test.js
+++ b/ui/src/components/ChatInput.test.js
@@ -101,10 +101,11 @@ describe('ChatInput', () => {
 	});
 
 	test('Enter on touch device does not trigger send', async () => {
-		// 模拟触屏设备：(pointer: coarse) → true
+		// 模拟纯触屏设备：pointer:coarse + hover:none → isTouchDevice=true
 		const origMM = window.matchMedia;
 		window.matchMedia = vi.fn((query) => ({
 			matches: query === '(pointer: coarse)' || query === '(any-pointer: coarse)',
+			// (hover: hover) 返回 false → canHover=false → 纯触屏
 			media: query,
 			addEventListener: vi.fn(),
 			removeEventListener: vi.fn(),
@@ -135,6 +136,48 @@ describe('ChatInput', () => {
 			await textarea.trigger('keydown', { key: 'Enter', shiftKey: false });
 			expect(wrapper.emitted('send')).toBeFalsy();
 		}
+
+		window.matchMedia = origMM;
+	});
+
+	test('Enter on touch laptop triggers send (isTouch=true, canHover=true)', async () => {
+		// 模拟触控笔记本：pointer:coarse + hover:hover → isTouchDevice=false
+		const origMM = window.matchMedia;
+		window.matchMedia = vi.fn((query) => ({
+			matches: query === '(pointer: coarse)'
+				|| query === '(any-pointer: coarse)'
+				|| query === '(hover: hover)',
+			media: query,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		}));
+
+		const pinia = createPinia();
+		setActivePinia(pinia);
+
+		const wrapper = mount(ChatInput, {
+			props: { modelValue: 'hello', sending: false, disabled: false },
+			global: {
+				plugins: [pinia],
+				stubs: {
+					UTextarea: UTextareaStub,
+					UButton: UButtonStub,
+					UIcon: UIconStub,
+					TouchSpeakOverlay: true,
+				},
+				mocks: { $t: (key) => key },
+			},
+		});
+
+		// isTouchDevice 应为 false（触控笔记本走桌面分支）
+		expect(wrapper.vm.isTouchDevice).toBe(false);
+
+		const textarea = wrapper.find('textarea');
+		await textarea.trigger('keydown', { key: 'Enter', shiftKey: false, isComposing: false });
+		expect(wrapper.emitted('send')).toBeTruthy();
 
 		window.matchMedia = origMM;
 	});

--- a/ui/src/components/ChatInput.vue
+++ b/ui/src/components/ChatInput.vue
@@ -224,7 +224,7 @@ export default {
 	},
 	computed: {
 		isTouchDevice() {
-			return this.envStore.isTouch;
+			return this.envStore.isTouch && !this.envStore.canHover;
 		},
 		canSend() {
 			const hasText = !!(this.modelValue && this.modelValue.trim());


### PR DESCRIPTION
## 问题

修复两个相关 issue，根因相同：

- **#6** Web 端回车键应发送消息，而不是换行
- **#5** Microsoft Edge 聊天输入框显示不出来

## 根因分析

`isTouchDevice` 依赖 CSS media query `(pointer: coarse)` 判断是否为触屏设备。

问题在于触控笔记本（Surface、带触控屏的 Windows 笔记本）以及 Edge 浏览器在某些 Windows 设备上，`(pointer: coarse)` 返回 `true`，导致：
1. `isTouchDevice = true` → `onKeydown` 提前 return → Enter 变换行
2. 桌面输入框组件（non-touch 分支）不渲染 → Edge 下输入框不显示

## 修复方案

```js
// Before
isTouchDevice() {
  return this.envStore.isTouch;
}

// After
isTouchDevice() {
  return this.envStore.isTouch && !this.envStore.canHover;
}
```

`canHover` 对应 `(hover: hover)`，纯触屏设备（手机/平板）不支持 hover，触控笔记本支持。

| 设备类型 | isTouch | canHover | isTouchDevice（修复后） |
|---------|---------|----------|------------------------|
| 手机/平板 | true | false | ✅ true（触屏模式）|
| 触控笔记本/Surface | true | true | ✅ false（桌面模式）|
| 普通桌面 | false | true | ✅ false（桌面模式）|

## 改动范围

- `ui/src/components/ChatInput.vue`：1 行核心逻辑修改
- `ui/src/components/ChatInput.test.js`：新增测试覆盖触控笔记本场景

Closes #6
Closes #5