### PR TITLE
fix(chat-store): preserve messages on agent lifecycle:error

### DIFF
--- a/ui/src/stores/chat.store.js
+++ b/ui/src/stores/chat.store.js
@@ -864,9 +864,10 @@ export const useChatStore = defineStore('chat', {
 				else if (data?.phase === 'error') {
 					console.debug('[chat] agent lifecycle:error runId=%s', this.streamingRunId);
 					this.__agentSettled = true;
-					this.__cleanupStreaming();
+					this.__cleanupTimersAndListeners();
+					this.__clearStreamingFlags();
 					this.sending = false;
-					// 错误信息由调用方通过 catch 或 store state 处理
+					this.__reconcileMessages();
 				}
 			}
 		},

--- a/ui/src/stores/chat.store.test.js
+++ b/ui/src/stores/chat.store.test.js
@@ -1369,10 +1369,15 @@ describe('useChatStore', () => {
 			expect(store.streamingRunId).toBeNull();
 		});
 
-		test('lifecycle error：结算 agent，清理 streaming，sending 置 false', () => {
+		test('lifecycle error：结算 agent，clearing streaming flags，sending 置 false', () => {
 			const botsStore = useBotsStore();
 			botsStore.setBots([{ id: '1', online: true }]);
 			const conn = mockConn();
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') return Promise.resolve({ messages: [] });
+				if (method === 'chat.history') return Promise.resolve({ sessionId: 'sess-1' });
+				return Promise.resolve(null);
+			});
 			mockConnections.set('1', conn);
 
 			const store = useChatStore();
@@ -1389,8 +1394,61 @@ describe('useChatStore', () => {
 
 			expect(store.__agentSettled).toBe(true);
 			expect(store.sending).toBe(false);
-			// 本地 streaming 条目被清理
-			expect(store.messages.some((m) => m._local)).toBe(false);
+			expect(store.streamingRunId).toBeNull();
+		});
+
+		test('lifecycle error：不删除本地消息', () => {
+			const botsStore = useBotsStore();
+			botsStore.setBots([{ id: '1', online: true }]);
+			const conn = mockConn();
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') return Promise.resolve({ messages: [] });
+				if (method === 'chat.history') return Promise.resolve({ sessionId: 'sess-1' });
+				return Promise.resolve(null);
+			});
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			store.sessionId = 'sess-1';
+			store.botId = '1';
+			store.streamingRunId = 'run-1';
+			store.sending = true;
+			store.chatSessionKey = 'agent:main:main';
+			store.messages = [
+				{ id: '__local_user_1', _local: true, message: { role: 'user', content: 'hello' } },
+				{ id: '__local_bot_1', _local: true, _streaming: true, message: { role: 'assistant', content: '' } },
+			];
+
+			store.__onAgentEvent({ runId: 'run-1', stream: 'lifecycle', data: { phase: 'error' } });
+
+			// 本地消息不应被删除（由 __reconcileMessages 从服务端拉取后合并）
+			expect(store.messages).toHaveLength(2);
+		});
+
+		test('lifecycle error：调用 __reconcileMessages', () => {
+			const botsStore = useBotsStore();
+			botsStore.setBots([{ id: '1', online: true }]);
+			const conn = mockConn();
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') return Promise.resolve({ messages: [] });
+				if (method === 'chat.history') return Promise.resolve({ sessionId: 'sess-1' });
+				return Promise.resolve(null);
+			});
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			store.sessionId = 'sess-1';
+			store.botId = '1';
+			store.streamingRunId = 'run-1';
+			store.sending = true;
+			store.chatSessionKey = 'agent:main:main';
+			store.messages = [];
+
+			const reconcileSpy = vi.spyOn(store, '__reconcileMessages');
+
+			store.__onAgentEvent({ runId: 'run-1', stream: 'lifecycle', data: { phase: 'error' } });
+
+			expect(reconcileSpy).toHaveBeenCalledOnce();
 		});
 
 		test('__reconcileMessages 连接不存在时返回 false', async () => {


### PR DESCRIPTION
## 问题

修复 **Closes #11**：执行失败的对话被删除

用户反馈：agent 执行失败后，主人和 OpenClaw 的对话记录在 CoClaw 中消失，但在 OpenClaw 工作台中仍可见。

## 根因分析

`lifecycle:error` 时调用了 `__cleanupStreaming()`，该方法内部调用 `__removeLocalEntries()`，将所有 `_local: true` 的乐观消息全部删除。

**失败路径（修复前）：**
```
lifecycle:error
  → __cleanupStreaming()
    → __cleanupTimersAndListeners()
    → __removeLocalEntries()  ← 把用户消息和对话全删了！
```

**正常结束路径：**
```
lifecycle:end
  → __cleanupTimersAndListeners()
  → __clearStreamingFlags()
  → __reconcileMessages()  ← 从服务端重新拉消息
```

两条路径不一致，导致失败时消息被意外清空。

## 修复

```js
// Before
else if (data?.phase === "error") {
    this.__agentSettled = true;
    this.__cleanupStreaming();  // 内部会删消息！
    this.sending = false;
}

// After
else if (data?.phase === "error") {
    this.__agentSettled = true;
    this.__cleanupTimersAndListeners();
    this.__clearStreamingFlags();
    this.sending = false;
    this.__reconcileMessages();  // 从服务端拉真实消息
}
```

## 改动
- `ui/src/stores/chat.store.js`：3 行改动
- `ui/src/stores/chat.store.test.js`：新增测试覆盖 lifecycle:error 场景