### PR TITLE
fix: APP 切后台回前台时 WebSocket 立即重连，修复"会话已不存在"报错 (closes #3)

### DIFF
--- a/ui/src/services/bot-connection.js
+++ b/ui/src/services/bot-connection.js
@@ -64,6 +64,9 @@ export class BotConnection {
 
 		// 事件监听
 		this.__listeners = new Map();
+
+		// visibility 恢复重连
+		this.__boundVisibilityHandler = null;
 	}
 
 	/** @returns {'disconnected' | 'connecting' | 'connected'} */
@@ -76,6 +79,10 @@ export class BotConnection {
 		if (this.__ws) return;
 		console.debug('[BotConn] connect botId=%s', this.botId);
 		this.__intentionalClose = false;
+		if (typeof document !== 'undefined' && !this.__boundVisibilityHandler) {
+			this.__boundVisibilityHandler = () => this.__onVisibilityChange();
+			document.addEventListener('visibilitychange', this.__boundVisibilityHandler);
+		}
 		this.__doConnect();
 	}
 
@@ -379,10 +386,26 @@ export class BotConnection {
 		}
 	}
 
+	// --- Visibility 恢复重连 ---
+
+	__onVisibilityChange() {
+		if (typeof document === 'undefined') return;
+		if (document.visibilityState !== 'visible') return;
+		if (this.__intentionalClose || this.__state !== 'disconnected') return;
+		console.debug('[BotConn] visibility visible → immediate reconnect botId=%s', this.botId);
+		this.__clearReconnect();
+		this.__reconnectDelay = INITIAL_RECONNECT_MS;
+		this.__doConnect();
+	}
+
 	// --- 清理 ---
 
 	__cleanup() {
 		this.__clearHeartbeat();
+		if (this.__boundVisibilityHandler && typeof document !== 'undefined') {
+			document.removeEventListener('visibilitychange', this.__boundVisibilityHandler);
+			this.__boundVisibilityHandler = null;
+		}
 		const ws = this.__ws;
 		this.__ws = null;
 		if (ws) {

--- a/ui/src/services/bot-connection.test.js
+++ b/ui/src/services/bot-connection.test.js
@@ -795,3 +795,119 @@ describe('BotConnection – stale WS guard', () => {
 		expect(conn.state).toBe('connected');
 	});
 });
+
+describe('BotConnection – visibility change reconnect', () => {
+	let savedDoc;
+	let mockDoc;
+
+	beforeEach(() => {
+		MockWebSocket.reset();
+		vi.useFakeTimers();
+		// 模拟 document
+		savedDoc = globalThis.document;
+		mockDoc = {
+			visibilityState: 'visible',
+			__listeners: {},
+			addEventListener(evt, cb) {
+				if (!this.__listeners[evt]) this.__listeners[evt] = [];
+				this.__listeners[evt].push(cb);
+			},
+			removeEventListener(evt, cb) {
+				if (!this.__listeners[evt]) return;
+				this.__listeners[evt] = this.__listeners[evt].filter(fn => fn !== cb);
+			},
+			simulateVisibility(state) {
+				this.visibilityState = state;
+				(this.__listeners['visibilitychange'] ?? []).forEach(cb => cb());
+			},
+		};
+		globalThis.document = mockDoc;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		globalThis.document = savedDoc;
+	});
+
+	test('connect() registers visibilitychange listener on document', () => {
+		const conn = new BotConnection('b1', { baseUrl: 'http://localhost', WebSocket: MockWebSocket });
+		conn.connect();
+		expect(mockDoc.__listeners['visibilitychange']?.length).toBe(1);
+	});
+
+	test('listener is registered only once even if connect() called multiple times', () => {
+		const conn = new BotConnection('b1', { baseUrl: 'http://localhost', WebSocket: MockWebSocket });
+		conn.connect();
+		conn.__ws = null; // 模拟 ws 已关闭
+		conn.connect();
+		expect(mockDoc.__listeners['visibilitychange']?.length).toBe(1);
+	});
+
+	test('visibility→visible while disconnected triggers immediate reconnect', () => {
+		const { conn, ws } = makeConnected();
+		ws.simulateClose(1006, 'abnormal'); // 非主动断连
+		expect(conn.state).toBe('disconnected');
+		expect(conn.__reconnectTimer).not.toBeNull();
+
+		mockDoc.simulateVisibility('visible');
+
+		// 应立即发起新连接，不等待 backoff 计时器
+		expect(MockWebSocket.instances.length).toBe(2);
+		expect(conn.state).toBe('connecting');
+	});
+
+	test('visibility→visible resets reconnect delay to INITIAL_RECONNECT_MS', () => {
+		const { conn, ws } = makeConnected();
+		conn.__reconnectDelay = 16000; // 模拟已累积的 backoff
+		ws.simulateClose(1006);
+		mockDoc.simulateVisibility('visible');
+		expect(conn.__reconnectDelay).toBe(1000);
+	});
+
+	test('visibility→visible cancels pending backoff timer', () => {
+		const { conn, ws } = makeConnected();
+		ws.simulateClose(1006);
+		const oldTimer = conn.__reconnectTimer;
+		expect(oldTimer).not.toBeNull();
+		mockDoc.simulateVisibility('visible');
+		expect(conn.__reconnectTimer).toBeNull(); // timer 已清除（doConnect 中会再建新 WS，不需要 timer）
+	});
+
+	test('visibility→hidden does not trigger reconnect', () => {
+		const { ws } = makeConnected();
+		ws.simulateClose(1006);
+		mockDoc.simulateVisibility('hidden');
+		// 不应产生新 WS
+		expect(MockWebSocket.instances.length).toBe(1);
+	});
+
+	test('visibility→visible while connected does nothing', () => {
+		const { conn } = makeConnected();
+		expect(conn.state).toBe('connected');
+		mockDoc.simulateVisibility('visible');
+		expect(MockWebSocket.instances.length).toBe(1);
+		expect(conn.state).toBe('connected');
+	});
+
+	test('visibility→visible after intentional disconnect does not reconnect', () => {
+		const { conn } = makeConnected();
+		conn.disconnect();
+		mockDoc.simulateVisibility('visible');
+		expect(MockWebSocket.instances.length).toBe(1);
+		expect(conn.state).toBe('disconnected');
+	});
+
+	test('disconnect() removes visibilitychange listener', () => {
+		const { conn } = makeConnected();
+		expect(mockDoc.__listeners['visibilitychange']?.length).toBe(1);
+		conn.disconnect();
+		expect((mockDoc.__listeners['visibilitychange'] ?? []).length).toBe(0);
+	});
+
+	test('bot.unbound removes visibilitychange listener', () => {
+		const { conn, ws } = makeConnected();
+		expect(mockDoc.__listeners['visibilitychange']?.length).toBe(1);
+		ws.simulateMessage({ type: 'bot.unbound' });
+		expect((mockDoc.__listeners['visibilitychange'] ?? []).length).toBe(0);
+	});
+});


### PR DESCRIPTION
### 改动内容
APP 切后台再回前台时，WebSocket 立即重连（跳过退避延迟），避免用户看到"会话已不存在"错误。

### 原因
关联 issue #3

用户从 APP 外返回 APP 时，必现"会话已不存在"报错。根因：`BotConnection` 不监听 `visibilitychange` 事件，APP 切后台时 WS 被 OS 杀掉或超时断开，回前台后只能等指数退避重连（最长 30 秒），期间 ChatPage 尝试加载 session 失败导致报错退出。

### 改动范围
- `ui/src/services/bot-connection.js` — +23 行
  - `connect()`: 注册 `visibilitychange` 监听（有 SSR 守卫、幂等检查）
  - `__onVisibilityChange()`: 页面 visible 且 WS 已断开时，重置退避延迟并立即重连
  - `__cleanup()`: 移除监听防内存泄漏
- `ui/src/services/bot-connection.test.js` — +116 行
  - 10 个新测试覆盖各场景

### 测试说明
- 新增 10 个单测（visible+disconnected 触发重连、connected 不触发、hidden 不触发、主动断连不触发、监听器注册/清理等）
- 全量 79 个 bot-connection 测试通过

### 如何验证
1. 在手机上打开 coclaw APP，进入会话页
2. 切到其他 APP 等待 30 秒以上
3. 切回 coclaw，应该立即重连并正常显示会话内容（不再报"会话已不存在"）
