### PR TITLE
fix: channel-plugin capabilities.media 设为 true (closes #16)

### DIFF
--- a/plugins/openclaw/src/channel-plugin.js
+++ b/plugins/openclaw/src/channel-plugin.js
@@ -22,7 +22,7 @@ export const coclawChannelPlugin = {
 	capabilities: {
 		chatTypes: ['direct'],
 		nativeCommands: true,
-		media: false,
+		media: true,
 		reactions: false,
 		threads: false,
 		polls: false,


### PR DESCRIPTION
### 改动内容
将 channel-plugin 的 `capabilities.media` 从 `false` 改为 `true`。

### 原因
关联 issue #16

coclaw 已支持图片附件发送，但 channel 能力声明仍为 `media: false`，可能影响 OpenClaw 的 outbound 媒体投递和未来媒体功能。

### 改动范围
- `plugins/openclaw/src/channel-plugin.js` — 1 行

### 测试说明
- 现有 channel-plugin 测试不检查 media 值，无需更新
- 不影响现有功能

### 如何验证
改动后 OpenClaw 可识别 coclaw channel 支持媒体，outbound 媒体消息不再被跳过。