### PR TITLE
fix: 定期清理过期 uiTickets，防止内存泄漏 (closes #25)

### DIFF
--- a/server/src/bot-ws-hub.js
+++ b/server/src/bot-ws-hub.js
@@ -7,9 +7,12 @@ import { findBotById, findBotByTokenHash, updateBotName } from './repos/bot.repo
 const botSockets = new Map();
 const uiSockets = new Map();
 const uiTickets = new Map();
+const TICKET_GC_INTERVAL_MS = 5 * 60_000; // 每 5 分钟清理过期 ticket
+
 const botRpcPending = new Map();
 let wsServer = null;
 let wsSessionMiddleware = null;
+let ticketGcTimer = null;
 let botRpcSeq = 1;
 
 export const botStatusEmitter = new EventEmitter();
@@ -365,6 +368,23 @@ export function listOnlineBotIds() {
 	return new Set(botSockets.keys());
 }
 
+/**
+ * 清理 Map 中 expiresAt 已过期的条目
+ * @param {Map<string, { expiresAt: number }>} map
+ * @returns {number} 清理的条目数
+ */
+export function pruneExpiredTickets(map) {
+	const now = Date.now();
+	let pruned = 0;
+	for (const [key, info] of map) {
+		if (info.expiresAt < now) {
+			map.delete(key);
+			pruned++;
+		}
+	}
+	return pruned;
+}
+
 export function createUiWsTicket({ botId, userId, ttlMs = 60_000 }) {
 	const ticket = crypto.randomBytes(16).toString('hex');
 	uiTickets.set(ticket, {
@@ -379,6 +399,11 @@ export function createUiWsTicket({ botId, userId, ttlMs = 60_000 }) {
 export function attachBotWsHub(httpServer, { sessionMiddleware } = {}) {
 	wsSessionMiddleware = sessionMiddleware ?? null;
 	wsServer = new WebSocketServer({ noServer: true });
+
+	// 定期清理过期的 UI WS ticket，防止未消费的 ticket 内存泄漏
+	if (ticketGcTimer) clearInterval(ticketGcTimer);
+	ticketGcTimer = setInterval(() => pruneExpiredTickets(uiTickets), TICKET_GC_INTERVAL_MS);
+	ticketGcTimer.unref();
 
 	httpServer.on('upgrade', async (req, socket, head) => {
 		try {

--- a/server/src/bot-ws-hub.test.js
+++ b/server/src/bot-ws-hub.test.js
@@ -92,3 +92,45 @@ test('botPingTick: 大消息传输中途恢复——bufferedAmount 先高后低'
 	assert.equal(r.action, 'ok');
 	assert.equal(r.missCount, 0);
 });
+
+// --- pruneExpiredTickets tests ---
+
+import { pruneExpiredTickets } from './bot-ws-hub.js';
+
+test('pruneExpiredTickets: removes expired entries', () => {
+	const map = new Map([
+		['a', { expiresAt: Date.now() - 1000 }],
+		['b', { expiresAt: Date.now() - 5000 }],
+	]);
+	const pruned = pruneExpiredTickets(map);
+	assert.equal(pruned, 2);
+	assert.equal(map.size, 0);
+});
+
+test('pruneExpiredTickets: keeps unexpired entries', () => {
+	const map = new Map([
+		['alive', { expiresAt: Date.now() + 60_000 }],
+		['dead', { expiresAt: Date.now() - 1000 }],
+	]);
+	const pruned = pruneExpiredTickets(map);
+	assert.equal(pruned, 1);
+	assert.equal(map.size, 1);
+	assert.ok(map.has('alive'));
+	assert.ok(!map.has('dead'));
+});
+
+test('pruneExpiredTickets: returns 0 on empty map', () => {
+	const map = new Map();
+	const pruned = pruneExpiredTickets(map);
+	assert.equal(pruned, 0);
+});
+
+test('pruneExpiredTickets: returns 0 when all entries are fresh', () => {
+	const map = new Map([
+		['x', { expiresAt: Date.now() + 10_000 }],
+		['y', { expiresAt: Date.now() + 20_000 }],
+	]);
+	const pruned = pruneExpiredTickets(map);
+	assert.equal(pruned, 0);
+	assert.equal(map.size, 2);
+});


### PR DESCRIPTION
### 改动内容
在 `attachBotWsHub` 中添加定期 GC，每 5 分钟清理 `uiTickets` Map 中过期的 ticket。

### 原因
关联 issue #25。`uiTickets` 只在被消费时才 delete，如果 ticket 被创建但从未被 WS 连接使用（网络中断、页面关闭等），过期条目永远不会被清理，长期运行导致内存缓慢泄漏。

### 改动范围
- `server/src/bot-ws-hub.js`：+13 行
  - 常量 `TICKET_GC_INTERVAL_MS = 5 * 60_000`
  - `attachBotWsHub` 中启动 `setInterval` GC timer（`.unref()` 不阻止进程退出）
  - GC 逻辑：遍历 `uiTickets`，删除 `expiresAt < Date.now()` 的条目

### 测试说明
- 现有 9 个 bot-ws-hub 测试全部通过
- GC 逻辑极简（遍历 Map + 条件 delete），无额外测试需求

### 如何验证
1. 创建 ticket（`createUiWsTicket`）但不消费
2. 等待 5 分钟
3. 验证 ticket 已被 GC 清理（`authenticateUiTicket` 返回 invalid）