### PR TITLE
fix(ui): 降低 Vite 构建目标至 chrome80，兼容旧版 Android WebView (closes #9)

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -7,7 +7,7 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 export default defineConfig({
 	build: {
-		target: ['es2020', 'chrome90', 'edge90', 'safari14', 'firefox90'],
+		target: ['es2020', 'chrome80', 'edge80', 'safari14', 'firefox78'],
 	},
 	define: {
 		__APP_VERSION__: JSON.stringify(pkg.version),


### PR DESCRIPTION
### 改动内容
将 `ui/vite.config.js` 的 `build.target` 从 `chrome90` 降低至 `chrome80`。

### 原因
关联 issue #9。华为畅想20 SE（Android 10）等设备的系统 WebView 版本约为 Chrome 83-86，低于 Vite 当前构建目标 `chrome90`。这导致构建产物中可能包含 Chrome 90+ 才支持的语法，在旧 WebView 上白屏或渲染失败。

### 背景分析
- Capacitor APP 使用系统 WebView 渲染页面
- `android/variables.gradle` 中 `minSdkVersion = 24`（Android 7.0）
- Android 7.0 的默认 WebView 是 Chrome ~51，但可通过应用商店独立更新
- 大量国产手机（华为、OPPO、vivo）的 WebView 更新滞后，实际 Chrome 版本在 80-86
- `chrome80` 已支持 optional chaining、nullish coalescing 等 ES2020 特性

### 改动范围
- `ui/vite.config.js`：1 行
  - `chrome90` → `chrome80`
  - `edge90` → `edge80`
  - `firefox90` → `firefox78`（Firefox ESR 版本，对齐兼容性）

### 测试说明
- `npx vite build` 构建成功 ✅
- UI 724/724 单元测试通过 ✅
- 构建产物体积无显著变化（差异 <1KB）

### 如何验证
1. 使用 Chrome 83 UserAgent 或旧版 Android WebView 设备访问
2. 页面应正常渲染，无白屏