### PR TITLE
fix(server): 注册和修改密码增加最小 8 位长度校验 (closes #30)

### DIFF
--- a/server/src/routes/user.route.js
+++ b/server/src/routes/user.route.js
@@ -273,6 +273,12 @@ function validateChangePasswordPayload(payload) {
 			message: 'newPassword is required',
 		};
 	}
+	if (payload.newPassword.length < 8) {
+		return {
+			ok: false,
+			message: 'newPassword must be at least 8 characters',
+		};
+	}
 
 	return { ok: true };
 }

--- a/server/src/routes/user.route.test.js
+++ b/server/src/routes/user.route.test.js
@@ -343,7 +343,7 @@ test('changePasswordHandler: should return 401 when not authenticated', async ()
 	const req = {
 		isAuthenticated: () => false,
 		user: null,
-		body: { oldPassword: 'a', newPassword: 'b' },
+		body: { oldPassword: 'oldpass12', newPassword: 'newpass12' },
 	};
 	const res = createRes();
 
@@ -357,7 +357,7 @@ test('changePasswordHandler: should return 401 when service returns INVALID_CRED
 	const req = {
 		isAuthenticated: () => true,
 		user: { id: 123n },
-		body: { oldPassword: 'wrong', newPassword: 'new' },
+		body: { oldPassword: 'wrongpass', newPassword: 'newpass12' },
 	};
 	const res = createRes();
 
@@ -377,7 +377,7 @@ test('changePasswordHandler: should return 400 when service returns NO_LOCAL_AUT
 	const req = {
 		isAuthenticated: () => true,
 		user: { id: 123n },
-		body: { oldPassword: 'a', newPassword: 'b' },
+		body: { oldPassword: 'oldpass12', newPassword: 'newpass12' },
 	};
 	const res = createRes();
 
@@ -397,7 +397,7 @@ test('changePasswordHandler: should return 200 on success', async () => {
 	const req = {
 		isAuthenticated: () => true,
 		user: { id: 123n },
-		body: { oldPassword: 'old', newPassword: 'new' },
+		body: { oldPassword: 'oldpass12', newPassword: 'newpass12' },
 	};
 	const res = createRes();
 
@@ -436,4 +436,17 @@ test('userRouter: should register routes without /me', () => {
 
 	const meRoute = routes.find((route) => route.path === '/me');
 	assert.equal(meRoute, undefined);
+});
+
+// --- password minimum length ---
+test('changePasswordHandler: should reject newPassword shorter than 8 chars', async () => {
+	const req = {
+		isAuthenticated: () => true,
+		user: { id: 1n },
+		body: { oldPassword: 'oldpass123', newPassword: 'short' },
+	};
+	const res = { status(c) { this.statusCode = c; return this; }, json(b) { this.body = b; } };
+	await changePasswordHandler(req, res, () => {});
+	assert.equal(res.statusCode, 400);
+	assert.match(res.body.message, /at least 8/);
 });

--- a/server/src/services/local-auth.svc.js
+++ b/server/src/services/local-auth.svc.js
@@ -131,6 +131,13 @@ export async function createLocalAccount(input, deps = {}) {
 			message: 'password is required',
 		};
 	}
+	if (password.length < 8) {
+		return {
+			ok: false,
+			code: 'INVALID_INPUT',
+			message: 'password must be at least 8 characters',
+		};
+	}
 
 	const nameCheck = validateLoginName(loginName);
 	if (!nameCheck.valid) {

--- a/server/src/services/local-auth.svc.test.js
+++ b/server/src/services/local-auth.svc.test.js
@@ -48,7 +48,7 @@ test('loginByLoginName: should reject invalid input', async () => {
 test('loginByLoginName: should reject when user not found', async () => {
 	const result = await loginByLoginName({
 		loginName: 'alice',
-		password: 'pwd',
+		password: 'password123',
 	}, {
 		findByLoginName: async () => null,
 	});
@@ -60,7 +60,7 @@ test('loginByLoginName: should reject when user not found', async () => {
 test('loginByLoginName: should reject locked account', async () => {
 	const result = await loginByLoginName({
 		loginName: 'alice',
-		password: 'pwd',
+		password: 'password123',
 	}, {
 		findByLoginName: async () => makeLocalAuth({ userLocked: true }),
 	});
@@ -72,7 +72,7 @@ test('loginByLoginName: should reject locked account', async () => {
 test('loginByLoginName: should reject wrong password', async () => {
 	const result = await loginByLoginName({
 		loginName: 'alice',
-		password: 'wrong',
+		password: 'wrongpass1',
 	}, {
 		findByLoginName: async () => makeLocalAuth(),
 		scryptImpl: {
@@ -89,7 +89,7 @@ test('loginByLoginName: should return user and touch login time', async () => {
 
 	const result = await loginByLoginName({
 		loginName: 'alice',
-		password: 'correct',
+		password: 'correctpw',
 	}, {
 		findByLoginName: async () => makeLocalAuth({ userId: 987n }),
 		scryptImpl: {
@@ -171,7 +171,7 @@ test('createLocalAccount: should reject empty password', async () => {
 test('createLocalAccount: should reject invalid loginName format', async () => {
 	const result = await createLocalAccount({
 		loginName: '_a',
-		password: 'secret',
+		password: 'secret12345',
 	});
 
 	assert.equal(result.ok, false);
@@ -181,7 +181,7 @@ test('createLocalAccount: should reject invalid loginName format', async () => {
 test('createLocalAccount: should reject reserved loginName', async () => {
 	const result = await createLocalAccount({
 		loginName: 'admin',
-		password: 'secret',
+		password: 'secret12345',
 	});
 
 	assert.equal(result.ok, false);
@@ -191,7 +191,7 @@ test('createLocalAccount: should reject reserved loginName', async () => {
 test('createLocalAccount: should return LOGIN_NAME_TAKEN on P2002', async () => {
 	const result = await createLocalAccount({
 		loginName: 'alice',
-		password: 'secret',
+		password: 'secret12345',
 	}, {
 		genId: () => 778899n,
 		scryptImpl: {
@@ -214,7 +214,7 @@ test('createLocalAccount: should return ok with session user and touch login tim
 
 	const result = await createLocalAccount({
 		loginName: 'alice',
-		password: 'secret',
+		password: 'secret12345',
 	}, {
 		genId: () => 778899n,
 		scryptImpl: {
@@ -239,6 +239,16 @@ test('createLocalAccount: should return ok with session user and touch login tim
 	assert.deepEqual(createdPayload, {
 		userId: 778899n,
 		loginName: 'alice',
-		passwordHash: 'hashed:secret',
+		passwordHash: 'hashed:secret12345',
 	});
+});
+
+test('createLocalAccount: should reject password shorter than 8 chars', async () => {
+	const result = await createLocalAccount({
+		loginName: 'testuser',
+		password: 'short',
+	});
+	assert.equal(result.ok, false);
+	assert.equal(result.code, 'INVALID_INPUT');
+	assert.match(result.message, /at least 8/);
 });


### PR DESCRIPTION
### 改动内容
为注册和修改密码接口增加密码最小长度 8 位的校验。

### 原因
关联 #30。原代码只检查密码不为空，允许 1 个字符的弱密码。

### 改动范围
- `server/src/routes/user.route.js`：`validateChangePasswordPayload` 增加 `newPassword.length < 8` 校验
- `server/src/services/local-auth.svc.js`：`createLocalAccount` 增加 `password.length < 8` 校验
- 测试文件中密码值更新为 >= 8 字符以适配新校验

### 测试说明
- 新增 2 个测试：密码短于 8 位被拒绝（注册 + 修改密码）
- 现有测试密码值已调整
- user.route 17/17 ✅ | local-auth.svc 14/14 ✅

### 如何验证
1. 注册时使用 7 位密码 → 返回 400
2. 修改密码时新密码 7 位 → 返回 400
3. 8 位及以上正常通过