### PR TITLE
fix(ui): Dashboard 频道状态显示名称，花费数据不可用时隐藏 (closes #54)

### DIFF
--- a/ui/src/components/dashboard/InstanceOverview.test.js
+++ b/ui/src/components/dashboard/InstanceOverview.test.js
@@ -45,11 +45,20 @@ describe('InstanceOverview', () => {
 		expect(wrapper.text()).toMatch(/12\.50/);
 	});
 
-	test('formatCost without total shows —', () => {
+	test('cost section hidden when monthlyCost has no total', () => {
 		const wrapper = mountOverview({
 			instance: { name: 'Bot', online: true, monthlyCost: {}, channels: [] },
 		});
-		expect(wrapper.text()).toContain('—');
+		expect(wrapper.text()).not.toContain('dashboard.monthlyCost');
+		expect(wrapper.text()).not.toContain('—');
+	});
+
+	test('cost section shown when total is 0', () => {
+		const wrapper = mountOverview({
+			instance: { name: 'Bot', online: true, monthlyCost: { total: 0, currency: 'USD' }, channels: [] },
+		});
+		expect(wrapper.text()).toMatch(/0\.00/);
+		expect(wrapper.text()).toContain('dashboard.monthlyCost');
 	});
 
 	test('displays plugin and claw version', () => {
@@ -60,12 +69,14 @@ describe('InstanceOverview', () => {
 		expect(wrapper.text()).toContain('2.0');
 	});
 
-	test('displays channel status icons', () => {
+	test('displays channel status icons with channel names', () => {
 		const wrapper = mountOverview({
 			instance: { name: 'Bot', online: true, channels: [{ id: 'discord', connected: true }, { id: 'slack', connected: false }] },
 		});
 		expect(wrapper.text()).toContain('✅');
 		expect(wrapper.text()).toContain('❌');
+		expect(wrapper.text()).toContain('discord');
+		expect(wrapper.text()).toContain('slack');
 	});
 
 	test('displays agent count', () => {

--- a/ui/src/components/dashboard/InstanceOverview.vue
+++ b/ui/src/components/dashboard/InstanceOverview.vue
@@ -9,7 +9,7 @@
 				></span>
 				<h2 class="text-lg font-semibold">{{ instance.name }}</h2>
 			</div>
-			<div v-if="instance.monthlyCost" class="text-right">
+			<div v-if="instance.monthlyCost && typeof instance.monthlyCost.total === 'number'" class="text-right">
 				<p class="text-2xl font-bold tracking-tight">{{ formatCost(instance.monthlyCost) }}</p>
 				<p class="text-xs text-muted">{{ $t('dashboard.monthlyCost') }}</p>
 			</div>
@@ -18,9 +18,10 @@
 		<div class="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted">
 			<span v-if="instance.pluginVersion">{{ $t('bots.pluginVersion') }}{{ instance.pluginVersion }}</span>
 			<span v-if="instance.clawVersion">{{ $t('bots.clawVersion') }}{{ instance.clawVersion }}</span>
-			<span v-if="instance.channels?.length" class="flex items-center gap-1">
-				<span v-for="ch in instance.channels" :key="ch.id" :title="ch.id">
-					{{ ch.connected ? '✅' : '❌' }}
+			<span v-if="instance.channels?.length" class="flex items-center gap-1.5">
+				<span v-for="ch in instance.channels" :key="ch.id" class="inline-flex items-center gap-0.5" :title="ch.id">
+					<span class="text-[10px]">{{ ch.connected ? '✅' : '❌' }}</span>
+					<span>{{ ch.id }}</span>
 				</span>
 			</span>
 			<UBadge color="primary" variant="subtle" size="xs">{{ agentCount }} {{ $t('dashboard.agents') }}</UBadge>


### PR DESCRIPTION
### 改动内容

Dashboard InstanceOverview 频道状态 emoji 旁显示频道名称，花费区域在数据不可用时完全隐藏。

### 原因

Closes #54（B1 + B2）

- B1：频道状态仅显示 ✅/❌ emoji，缺少频道名称，用户无法识别
- B2：`monthlyCost` 对象存在但 `total` 非数字时，显示空白花费造成困惑

### 改动范围

- `ui/src/components/dashboard/InstanceOverview.vue`：频道 emoji 旁加频道名称，花费 `v-if` 增加 `typeof total === "number"` 判断（+4/-3 行）
- `ui/src/components/dashboard/InstanceOverview.test.js`：验证频道名称显示（+3/-1 行）

### 测试说明

- InstanceOverview.test.js: 9/9 ✅

### 如何验证

1. 打开 Agent Dashboard → 频道状态显示 `✅ discord` / `❌ slack`（带名称）
2. 无花费数据时花费区域不显示

— [CoClaw Team](https://github.com/coclaw)