### PR TITLE
feat: 新增管理员仪表盘，展示系统关键运营数据 (closes #55)

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -8,6 +8,7 @@ import passport from 'passport';
 import { setupPassport } from './config/passport.js';
 import { prisma } from './db/prisma.js';
 import { PrismaSessionStore } from './db/prisma-session-store.js';
+import { adminRouter } from './routes/admin.route.js';
 import { authRouter } from './routes/auth.route.js';
 import { botRouter } from './routes/bot.route.js';
 import { clawRouter } from './routes/claw.route.js';
@@ -88,6 +89,7 @@ export function createApp() {
 		res.status(200).json({ ok: true });
 	});
 
+	app.use('/api/v1/admin', adminRouter);
 	app.use('/api/v1/info', infoRouter);
 	app.use('/api/v1/auth', authRouter);
 	app.use('/api/v1/user', userRouter);

--- a/server/src/middlewares/require-admin.js
+++ b/server/src/middlewares/require-admin.js
@@ -1,0 +1,9 @@
+export function requireAdmin(req, res, next) {
+	if (!req.isAuthenticated?.() || !req.user) {
+		return res.status(401).json({ code: 'UNAUTHORIZED', message: 'Not authenticated' });
+	}
+	if (req.user.level !== -100) {
+		return res.status(403).json({ code: 'FORBIDDEN', message: 'Admin access required' });
+	}
+	next();
+}

--- a/server/src/middlewares/require-admin.test.js
+++ b/server/src/middlewares/require-admin.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { requireAdmin } from './require-admin.js';
+
+function mockRes() {
+	const res = {
+		_status: null,
+		_json: null,
+		status(code) { res._status = code; return res; },
+		json(body) { res._json = body; return res; },
+	};
+	return res;
+}
+
+test('requireAdmin: 未认证（无 isAuthenticated）返回 401', () => {
+	const req = { user: null };
+	const res = mockRes();
+	let called = false;
+
+	requireAdmin(req, res, () => { called = true; });
+
+	assert.equal(res._status, 401);
+	assert.equal(res._json.code, 'UNAUTHORIZED');
+	assert.equal(called, false);
+});
+
+test('requireAdmin: isAuthenticated 返回 false 则 401', () => {
+	const req = { isAuthenticated: () => false, user: { level: -100 } };
+	const res = mockRes();
+	let called = false;
+
+	requireAdmin(req, res, () => { called = true; });
+
+	assert.equal(res._status, 401);
+	assert.equal(called, false);
+});
+
+test('requireAdmin: 非 admin 用户返回 403', () => {
+	const req = { isAuthenticated: () => true, user: { level: 0 } };
+	const res = mockRes();
+	let called = false;
+
+	requireAdmin(req, res, () => { called = true; });
+
+	assert.equal(res._status, 403);
+	assert.equal(res._json.code, 'FORBIDDEN');
+	assert.equal(called, false);
+});
+
+test('requireAdmin: admin 用户通过', () => {
+	const req = { isAuthenticated: () => true, user: { level: -100 } };
+	const res = mockRes();
+	let called = false;
+
+	requireAdmin(req, res, () => { called = true; });
+
+	assert.equal(res._status, null);
+	assert.equal(called, true);
+});

--- a/server/src/repos/admin.repo.js
+++ b/server/src/repos/admin.repo.js
@@ -1,0 +1,27 @@
+import { prisma } from '../db/prisma.js';
+
+export async function countUsers(db = prisma) {
+	return db.user.count();
+}
+
+export async function countUsersCreatedSince(date, db = prisma) {
+	return db.user.count({ where: { createdAt: { gte: date } } });
+}
+
+export async function countUsersActiveSince(date, db = prisma) {
+	return db.user.count({ where: { lastLoginAt: { gte: date } } });
+}
+
+export async function topActiveUsers(limit, db = prisma) {
+	const rows = await db.user.findMany({
+		where: { lastLoginAt: { not: null } },
+		orderBy: { lastLoginAt: 'desc' },
+		take: limit,
+		select: { id: true, name: true, lastLoginAt: true },
+	});
+	return rows.map(u => ({ ...u, id: u.id.toString() }));
+}
+
+export async function countBots(db = prisma) {
+	return db.bot.count();
+}

--- a/server/src/repos/admin.repo.test.js
+++ b/server/src/repos/admin.repo.test.js
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+	countUsers,
+	countUsersCreatedSince,
+	countUsersActiveSince,
+	topActiveUsers,
+	countBots,
+} from './admin.repo.js';
+
+test('countUsers: 调用 prisma.user.count()', async () => {
+	const db = { user: { count: async () => 10 } };
+	assert.equal(await countUsers(db), 10);
+});
+
+test('countUsersCreatedSince: 传递 gte 条件', async () => {
+	const since = new Date('2026-01-01');
+	let captured = null;
+	const db = {
+		user: {
+			count: async (args) => { captured = args; return 3; },
+		},
+	};
+
+	const result = await countUsersCreatedSince(since, db);
+
+	assert.equal(result, 3);
+	assert.deepEqual(captured, { where: { createdAt: { gte: since } } });
+});
+
+test('countUsersActiveSince: 传递 lastLoginAt gte 条件', async () => {
+	const since = new Date('2026-03-01');
+	let captured = null;
+	const db = {
+		user: {
+			count: async (args) => { captured = args; return 5; },
+		},
+	};
+
+	const result = await countUsersActiveSince(since, db);
+
+	assert.equal(result, 5);
+	assert.deepEqual(captured, { where: { lastLoginAt: { gte: since } } });
+});
+
+test('topActiveUsers: 返回结果并将 BigInt id 转为 string', async () => {
+	const db = {
+		user: {
+			findMany: async () => [
+				{ id: 123456789n, name: 'Alice', lastLoginAt: new Date('2026-03-20') },
+				{ id: 987654321n, name: 'Bob', lastLoginAt: new Date('2026-03-19') },
+			],
+		},
+	};
+
+	const result = await topActiveUsers(5, db);
+
+	assert.equal(result.length, 2);
+	assert.equal(result[0].id, '123456789');
+	assert.equal(typeof result[0].id, 'string');
+	assert.equal(result[1].name, 'Bob');
+});
+
+test('topActiveUsers: 传递正确的查询参数', async () => {
+	let captured = null;
+	const db = {
+		user: {
+			findMany: async (args) => { captured = args; return []; },
+		},
+	};
+
+	await topActiveUsers(3, db);
+
+	assert.deepEqual(captured, {
+		where: { lastLoginAt: { not: null } },
+		orderBy: { lastLoginAt: 'desc' },
+		take: 3,
+		select: { id: true, name: true, lastLoginAt: true },
+	});
+});
+
+test('countBots: 调用 prisma.bot.count()', async () => {
+	const db = { bot: { count: async () => 7 } };
+	assert.equal(await countBots(db), 7);
+});

--- a/server/src/routes/admin.route.js
+++ b/server/src/routes/admin.route.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+
+import { requireAdmin } from '../middlewares/require-admin.js';
+import { getAdminDashboard } from '../services/admin-dashboard.svc.js';
+
+export const adminRouter = Router();
+
+export async function dashboardHandler(req, res, next, deps = {}) {
+	const getDashboard = deps.getAdminDashboard ?? getAdminDashboard;
+	try {
+		const data = await getDashboard();
+		res.json(data);
+	}
+	catch (err) {
+		next(err);
+	}
+}
+
+adminRouter.get('/dashboard', requireAdmin, (req, res, next) => dashboardHandler(req, res, next));

--- a/server/src/routes/admin.route.test.js
+++ b/server/src/routes/admin.route.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { dashboardHandler } from './admin.route.js';
+
+function mockRes() {
+	const res = {
+		_json: null,
+		json(body) { res._json = body; return res; },
+	};
+	return res;
+}
+
+test('dashboardHandler: 正常返回 dashboard 数据', async () => {
+	const fakeData = { users: { total: 10 }, bots: { total: 2 } };
+	const res = mockRes();
+
+	await dashboardHandler({}, res, () => {}, {
+		getAdminDashboard: async () => fakeData,
+	});
+
+	assert.deepEqual(res._json, fakeData);
+});
+
+test('dashboardHandler: service 抛错时调用 next', async () => {
+	const err = new Error('boom');
+	let nextErr = null;
+
+	await dashboardHandler({}, mockRes(), (e) => { nextErr = e; }, {
+		getAdminDashboard: async () => { throw err; },
+	});
+
+	assert.equal(nextErr, err);
+});

--- a/server/src/services/admin-dashboard.svc.js
+++ b/server/src/services/admin-dashboard.svc.js
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module';
+
+import * as adminRepo from '../repos/admin.repo.js';
+import { listOnlineBotIds } from '../bot-ws-hub.js';
+
+const require = createRequire(import.meta.url);
+const { version: serverVersion } = require('../../package.json');
+
+/**
+ * @param {object} [deps] - 依赖注入
+ * @param {object} [deps.repo] - admin repo
+ * @param {Function} [deps.getOnlineBotCount] - 获取在线 bot 数
+ */
+export async function getAdminDashboard(deps = {}) {
+	const repo = deps.repo ?? adminRepo;
+	const getOnlineBotCount = deps.getOnlineBotCount ?? (() => listOnlineBotIds().size);
+
+	const todayStart = new Date();
+	todayStart.setHours(0, 0, 0, 0);
+
+	const [total, todayNew, todayActive, topActive, botsTotal] = await Promise.all([
+		repo.countUsers(),
+		repo.countUsersCreatedSince(todayStart),
+		repo.countUsersActiveSince(todayStart),
+		repo.topActiveUsers(10),
+		repo.countBots(),
+	]);
+
+	return {
+		users: { total, todayNew, todayActive },
+		topActiveUsers: topActive,
+		bots: {
+			total: botsTotal,
+			online: getOnlineBotCount(),
+		},
+		version: {
+			server: serverVersion,
+		},
+	};
+}

--- a/server/src/services/admin-dashboard.svc.test.js
+++ b/server/src/services/admin-dashboard.svc.test.js
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getAdminDashboard } from './admin-dashboard.svc.js';
+
+function mockRepo(overrides = {}) {
+	return {
+		countUsers: async () => overrides.total ?? 100,
+		countUsersCreatedSince: async () => overrides.todayNew ?? 5,
+		countUsersActiveSince: async () => overrides.todayActive ?? 20,
+		topActiveUsers: async () => overrides.topActive ?? [
+			{ id: '1', name: 'Alice', lastLoginAt: '2026-03-23T10:00:00Z' },
+		],
+		countBots: async () => overrides.botsTotal ?? 8,
+	};
+}
+
+test('getAdminDashboard: 返回正确的汇总结构', async () => {
+	const result = await getAdminDashboard({
+		repo: mockRepo(),
+		getOnlineBotCount: () => 3,
+	});
+
+	assert.equal(result.users.total, 100);
+	assert.equal(result.users.todayNew, 5);
+	assert.equal(result.users.todayActive, 20);
+	assert.equal(result.topActiveUsers.length, 1);
+	assert.equal(result.topActiveUsers[0].name, 'Alice');
+	assert.equal(result.bots.total, 8);
+	assert.equal(result.bots.online, 3);
+	assert.equal(typeof result.version.server, 'string');
+	assert.ok(result.version.server.length > 0);
+});
+
+test('getAdminDashboard: 自定义数据正确透传', async () => {
+	const result = await getAdminDashboard({
+		repo: mockRepo({ total: 50, todayNew: 2, todayActive: 10, botsTotal: 0, topActive: [] }),
+		getOnlineBotCount: () => 0,
+	});
+
+	assert.equal(result.users.total, 50);
+	assert.equal(result.users.todayNew, 2);
+	assert.equal(result.users.todayActive, 10);
+	assert.deepEqual(result.topActiveUsers, []);
+	assert.equal(result.bots.total, 0);
+	assert.equal(result.bots.online, 0);
+});
+
+test('getAdminDashboard: 并行调用所有 repo 方法', async () => {
+	const calls = [];
+	const repo = {
+		countUsers: async () => { calls.push('countUsers'); return 0; },
+		countUsersCreatedSince: async () => { calls.push('countUsersCreatedSince'); return 0; },
+		countUsersActiveSince: async () => { calls.push('countUsersActiveSince'); return 0; },
+		topActiveUsers: async () => { calls.push('topActiveUsers'); return []; },
+		countBots: async () => { calls.push('countBots'); return 0; },
+	};
+
+	await getAdminDashboard({ repo, getOnlineBotCount: () => 0 });
+
+	assert.equal(calls.length, 5);
+	assert.ok(calls.includes('countUsers'));
+	assert.ok(calls.includes('countUsersCreatedSince'));
+	assert.ok(calls.includes('countUsersActiveSince'));
+	assert.ok(calls.includes('topActiveUsers'));
+	assert.ok(calls.includes('countBots'));
+});

--- a/ui/src/components/DesktopSidebar.vue
+++ b/ui/src/components/DesktopSidebar.vue
@@ -91,7 +91,7 @@ export default {
 	},
 	computed: {
 		userMenuItems() {
-			return getUserMenuItems(this.$t);
+			return getUserMenuItems(this.$t, { isAdmin: this.user?.level === -100 });
 		},
 		userDisplayName() {
 			return getUserDisplayName(this.user);
@@ -100,6 +100,10 @@ export default {
 	methods: {
 		onMenuItemClick(itemId) {
 			this.menuOpen = false;
+			if (itemId === 'admin-dashboard') {
+				this.$router.push('/admin/dashboard');
+				return;
+			}
 			if (itemId === 'logout') {
 				this.$emit('logout');
 				return;

--- a/ui/src/constants/layout.data.js
+++ b/ui/src/constants/layout.data.js
@@ -1,12 +1,17 @@
 import openclawIcon from '../assets/bot-avatars/openclaw.svg';
 
-export function getUserMenuItems(t) {
-	return [
+export function getUserMenuItems(t, { isAdmin = false } = {}) {
+	const items = [];
+	if (isAdmin) {
+		items.push({ id: 'admin-dashboard', label: t('user.adminDashboard'), icon: 'i-lucide-layout-dashboard' });
+	}
+	items.push(
 		{ id: 'about', label: t('layout.menu.about'), icon: 'i-lucide-home' },
 		{ id: 'settings', label: t('layout.menu.settings'), icon: 'i-lucide-settings', separator: true },
 		{ id: 'profile', label: t('layout.menu.profile'), icon: 'i-lucide-user-round' },
 		{ id: 'logout', label: t('layout.menu.logout'), icon: 'i-lucide-log-out', separator: true },
-	];
+	);
+	return items;
 }
 
 export function getMobileTabs(t) {

--- a/ui/src/i18n/locales/en.js
+++ b/ui/src/i18n/locales/en.js
@@ -76,6 +76,7 @@ export const enMessages = {
 	},
 	user: {
 		role: 'Maintainer',
+		adminDashboard: 'Admin Dashboard',
 	},
 	settings: {
 		title: 'Settings',
@@ -142,6 +143,16 @@ export const enMessages = {
 		addAgent: 'Add Agent',
 		chat: 'Chat',
 		sessionNotReady: 'Session not ready, please try again later',
+	},
+	adminDashboard: {
+		title: 'Admin Dashboard',
+		totalUsers: 'Total Users',
+		todayNew: 'New Today',
+		todayActive: 'Active Today',
+		totalBots: 'Registered Claws',
+		serverVersion: 'Server Version',
+		topActiveUsers: 'Recently Active Users',
+		noData: 'No data',
 	},
 	dashboard: {
 		monthlyCost: 'Monthly cost',

--- a/ui/src/i18n/locales/zh-CN.js
+++ b/ui/src/i18n/locales/zh-CN.js
@@ -76,6 +76,7 @@ export const zhCNMessages = {
 	},
 	user: {
 		role: '维护者',
+		adminDashboard: '管理员仪表盘',
 	},
 	settings: {
 		title: '设置',
@@ -142,6 +143,16 @@ export const zhCNMessages = {
 		addAgent: '添加 Agent',
 		chat: '对话',
 		sessionNotReady: '会话尚未就绪，请稍后重试',
+	},
+	adminDashboard: {
+		title: '管理员仪表盘',
+		totalUsers: '注册用户',
+		todayNew: '今日新增',
+		todayActive: '今日活跃',
+		totalBots: '已注册 Claw',
+		serverVersion: '服务端版本',
+		topActiveUsers: '最近活跃用户',
+		noData: '暂无数据',
 	},
 	dashboard: {
 		monthlyCost: '本月花费',

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -87,6 +87,12 @@ const routes = [
 				meta: { requiresAuth: true, hideMobileNav: true },
 			},
 			{
+				path: 'admin/dashboard',
+				name: 'admin-dashboard',
+				component: () => import('../views/AdminDashboardPage.vue'),
+				meta: { requiresAuth: true, hideMobileNav: true },
+			},
+			{
 				path: 'about',
 				name: 'about',
 				component: AboutPage,

--- a/ui/src/services/admin.api.js
+++ b/ui/src/services/admin.api.js
@@ -1,0 +1,6 @@
+import { httpClient as client } from './http.js';
+
+export async function fetchAdminDashboard() {
+	const res = await client.get('/api/v1/admin/dashboard');
+	return res.data;
+}

--- a/ui/src/views/AdminDashboardPage.test.js
+++ b/ui/src/views/AdminDashboardPage.test.js
@@ -1,0 +1,127 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { vi } from 'vitest';
+
+import AdminDashboardPage from './AdminDashboardPage.vue';
+
+const mockFetchAdminDashboard = vi.fn();
+const mockNotifyError = vi.fn();
+
+vi.mock('../services/admin.api.js', () => ({
+	fetchAdminDashboard: (...args) => mockFetchAdminDashboard(...args),
+}));
+
+vi.mock('../composables/use-notify.js', () => ({
+	useNotify: () => ({
+		success: vi.fn(),
+		info: vi.fn(),
+		warning: vi.fn(),
+		error: mockNotifyError,
+	}),
+}));
+
+const fakeDashboard = {
+	users: { total: 100, todayNew: 5, todayActive: 23 },
+	topActiveUsers: [
+		{ id: '1', name: '张三', lastLoginAt: new Date(Date.now() - 180000).toISOString() },
+		{ id: '2', name: '李四', lastLoginAt: new Date(Date.now() - 7200000).toISOString() },
+	],
+	bots: { total: 10 },
+	version: { server: '0.4.2' },
+};
+
+const i18nMap = {
+	'adminDashboard.title': 'Admin Dashboard',
+	'adminDashboard.totalUsers': 'Total Users',
+	'adminDashboard.todayNew': 'New Today',
+	'adminDashboard.todayActive': 'Active Today',
+	'adminDashboard.totalBots': 'Registered Claws',
+	'adminDashboard.serverVersion': 'Server Version',
+	'adminDashboard.topActiveUsers': 'Recently Active Users',
+	'adminDashboard.noData': 'No data',
+	'chat.loading': 'Loading...',
+	'dashboard.justNow': 'Just now',
+	'dashboard.minutesAgo': '{n}m ago',
+	'dashboard.hoursAgo': '{n}h ago',
+	'dashboard.daysAgo': '{n}d ago',
+};
+
+function createWrapper() {
+	return mount(AdminDashboardPage, {
+		global: {
+			stubs: {
+				MobilePageHeader: { props: ['title'], template: '<div />' },
+			},
+			mocks: {
+				$t: (key, params) => {
+					let str = i18nMap[key] ?? key;
+					if (params) {
+						for (const [k, v] of Object.entries(params)) {
+							str = str.replace(`{${k}}`, v);
+						}
+					}
+					return str;
+				},
+			},
+		},
+	});
+}
+
+beforeEach(() => {
+	mockFetchAdminDashboard.mockReset();
+	mockNotifyError.mockReset();
+});
+
+test('should show loading state initially', async () => {
+	let resolve;
+	mockFetchAdminDashboard.mockReturnValue(new Promise((r) => { resolve = r; }));
+	const wrapper = createWrapper();
+	await wrapper.vm.$nextTick();
+
+	expect(wrapper.text()).toContain('Loading...');
+	resolve(fakeDashboard);
+	await flushPromises();
+});
+
+test('should render dashboard data after successful load', async () => {
+	mockFetchAdminDashboard.mockResolvedValueOnce(fakeDashboard);
+	const wrapper = createWrapper();
+	await flushPromises();
+
+	expect(wrapper.text()).toContain('100');
+	expect(wrapper.text()).toContain('5');
+	expect(wrapper.text()).toContain('23');
+	expect(wrapper.text()).toContain('10');
+	expect(wrapper.text()).toContain('v0.4.2');
+	expect(wrapper.text()).toContain('张三');
+	expect(wrapper.text()).toContain('李四');
+});
+
+test('should call notify.error on fetch failure', async () => {
+	mockFetchAdminDashboard.mockRejectedValueOnce(new Error('Network error'));
+	createWrapper();
+	await flushPromises();
+
+	expect(mockNotifyError).toHaveBeenCalledWith('Network error');
+});
+
+test('should format time ago correctly', async () => {
+	mockFetchAdminDashboard.mockResolvedValueOnce(fakeDashboard);
+	const wrapper = createWrapper();
+	await flushPromises();
+
+	// 180s = 3min -> "3m ago"
+	expect(wrapper.text()).toContain('3m ago');
+	// 7200s = 2h -> "2h ago"
+	expect(wrapper.text()).toContain('2h ago');
+});
+
+test('should show noData when topActiveUsers is empty', async () => {
+	mockFetchAdminDashboard.mockResolvedValueOnce({
+		...fakeDashboard,
+		topActiveUsers: [],
+	});
+	const wrapper = createWrapper();
+	await flushPromises();
+
+	expect(wrapper.text()).toContain('No data');
+});

--- a/ui/src/views/AdminDashboardPage.vue
+++ b/ui/src/views/AdminDashboardPage.vue
@@ -1,0 +1,108 @@
+<template>
+	<div class="flex min-h-0 flex-1 flex-col">
+		<MobilePageHeader :title="$t('adminDashboard.title')" />
+		<main class="flex-1 overflow-auto px-3 pt-4 pb-8 sm:px-4 lg:px-5">
+			<section class="mx-auto flex w-full max-w-3xl flex-col gap-5">
+				<!-- 桌面端标题 -->
+				<h1 class="hidden text-base font-medium md:flex">{{ $t('adminDashboard.title') }}</h1>
+
+				<p v-if="loading" class="text-sm text-muted">{{ $t('chat.loading') }}</p>
+
+				<template v-if="!loading && data">
+					<!-- 用户统计卡片 -->
+					<div class="grid grid-cols-3 gap-3">
+						<div class="rounded-xl bg-elevated p-4 text-center">
+							<p class="text-2xl font-semibold">{{ data.users.total }}</p>
+							<p class="mt-1 text-xs text-dimmed">{{ $t('adminDashboard.totalUsers') }}</p>
+						</div>
+						<div class="rounded-xl bg-elevated p-4 text-center">
+							<p class="text-2xl font-semibold">{{ data.users.todayNew }}</p>
+							<p class="mt-1 text-xs text-dimmed">{{ $t('adminDashboard.todayNew') }}</p>
+						</div>
+						<div class="rounded-xl bg-elevated p-4 text-center">
+							<p class="text-2xl font-semibold">{{ data.users.todayActive }}</p>
+							<p class="mt-1 text-xs text-dimmed">{{ $t('adminDashboard.todayActive') }}</p>
+						</div>
+					</div>
+
+					<!-- Claw 统计 + 版本 -->
+					<div class="rounded-xl bg-elevated p-4">
+						<div class="flex items-center justify-between text-sm">
+							<span class="text-dimmed">{{ $t('adminDashboard.totalBots') }}</span>
+							<span class="font-medium">{{ data.bots.total }}</span>
+						</div>
+						<div class="mt-2 flex items-center justify-between text-sm">
+							<span class="text-dimmed">{{ $t('adminDashboard.serverVersion') }}</span>
+							<span class="font-medium">v{{ data.version.server }}</span>
+						</div>
+					</div>
+
+					<!-- 最近活跃用户 -->
+					<div class="rounded-xl bg-elevated p-4">
+						<h2 class="mb-3 text-sm font-medium">{{ $t('adminDashboard.topActiveUsers') }}</h2>
+						<p v-if="!data.topActiveUsers?.length" class="text-sm text-dimmed">{{ $t('adminDashboard.noData') }}</p>
+						<ul v-else class="space-y-2">
+							<li
+								v-for="(user, idx) in data.topActiveUsers"
+								:key="user.id"
+								class="flex items-center justify-between text-sm"
+							>
+								<span>
+									<span class="mr-2 text-dimmed">{{ idx + 1 }}.</span>
+									<span>{{ user.name }}</span>
+								</span>
+								<span class="text-xs text-dimmed">{{ formatTimeAgo(user.lastLoginAt) }}</span>
+							</li>
+						</ul>
+					</div>
+				</template>
+			</section>
+		</main>
+	</div>
+</template>
+
+<script>
+import { useNotify } from '../composables/use-notify.js';
+import { fetchAdminDashboard } from '../services/admin.api.js';
+import MobilePageHeader from '../components/MobilePageHeader.vue';
+
+export default {
+	name: 'AdminDashboardPage',
+	components: { MobilePageHeader },
+	setup() {
+		return { notify: useNotify() };
+	},
+	data() {
+		return {
+			loading: false,
+			data: null,
+		};
+	},
+	async mounted() {
+		await this.loadData();
+	},
+	methods: {
+		async loadData() {
+			this.loading = true;
+			try {
+				this.data = await fetchAdminDashboard();
+			}
+			catch (err) {
+				this.notify.error(err?.response?.data?.message ?? err?.message ?? 'Load failed');
+			}
+			finally {
+				this.loading = false;
+			}
+		},
+		formatTimeAgo(iso) {
+			if (!iso) return '—';
+			const diff = (Date.now() - new Date(iso).getTime()) / 1000;
+			if (diff < 0 || Number.isNaN(diff)) return '—';
+			if (diff < 60) return this.$t('dashboard.justNow');
+			if (diff < 3600) return this.$t('dashboard.minutesAgo', { n: Math.floor(diff / 60) });
+			if (diff < 86400) return this.$t('dashboard.hoursAgo', { n: Math.floor(diff / 3600) });
+			return this.$t('dashboard.daysAgo', { n: Math.floor(diff / 86400) });
+		},
+	},
+};
+</script>

--- a/ui/src/views/UserPage.vue
+++ b/ui/src/views/UserPage.vue
@@ -55,11 +55,15 @@ export default {
 			return this.authStore.user?.id || '-';
 		},
 		menuItems() {
-			return getUserMenuItems(this.$t);
+			return getUserMenuItems(this.$t, { isAdmin: this.authStore.user?.level === -100 });
 		},
 	},
 	methods: {
 		onMenuClick(itemId) {
+			if (itemId === 'admin-dashboard') {
+				this.$router.push('/admin/dashboard');
+				return;
+			}
 			if (itemId === 'logout') {
 				this.authStore.logout().then(() => {
 					this.$router.replace('/about');


### PR DESCRIPTION
### 改动内容

在「我的」页面增加管理员仪表盘入口（仅 admin 可见），展示系统关键数据的只读概览页。

### 原因

Closes #55

管理员需要快速了解系统运营状况：用户量、活跃度、Claw 数量、版本号等。

### 改动范围

**Server 端（新增）**：
- `server/src/middlewares/require-admin.js`：管理员权限中间件（未认证 401 / 非管理员 403）
- `server/src/repos/admin.repo.js`：用户 / Bot 简单 COUNT 查询
- `server/src/services/admin-dashboard.svc.js`：数据汇总 + 在线 Bot 数 + 版本号
- `server/src/routes/admin.route.js`：`GET /api/v1/admin/dashboard`
- `server/src/app.js`：注册路由

**UI 端（新增）**：
- `ui/src/views/AdminDashboardPage.vue`：只读仪表盘页面（用户概览 / Claw 统计 / Top 10 活跃用户）
- `ui/src/services/admin.api.js`：API 调用
- `ui/src/views/UserPage.vue`：`level === -100` 时显示菜单入口
- `ui/src/router/index.js`：新增路由
- `ui/src/i18n/locales/zh-CN.js` / `en.js`：国际化

### 测试说明

- Server: 15/15 ✅（`node --test`）
- UI: 5/5 ✅（Vitest）

### 安全说明

- **前端**：菜单入口仅 `user.level === -100` 时渲染
- **后端**：`requireAdmin` 中间件二次校验，非管理员返回 403
- 纯只读，无任何写操作
- 所有查询均为简单 COUNT 或 LIMIT 10，无多表 JOIN

### 如何验证

1. 以 admin 账号登录（`level = -100`）→「我的」页面可见「管理员仪表盘」
2. 进入后展示：注册用户数、今日新增/活跃、Claw 统计、服务端版本、Top 10 活跃用户
3. 以普通用户登录 → 不可见
4. 直接请求 `/api/v1/admin/dashboard` → 403

— [CoClaw Team](https://github.com/coclaw)