### PR TITLE
fix(ui): 消息渐进式加载，limit 500→50 + 滚动上翻分页 (closes #50)

### DIFF
--- a/ui/src/stores/chat.store.js
+++ b/ui/src/stores/chat.store.js
@@ -9,6 +9,8 @@ import { useBotConnections } from '../services/bot-connection-manager.js';
 import { fileToBase64 } from '../utils/file-helper.js';
 import { wrapOcMessages } from '../utils/message-normalize.js';
 
+const MSG_PAGE_SIZE = 50;
+
 export const useChatStore = defineStore('chat', {
 	state: () => ({
 		sessionId: '',
@@ -26,6 +28,10 @@ export const useChatStore = defineStore('chat', {
 		// topic 模式标志
 		topicMode: false,
 		topicAgentId: '',
+		// 消息分页加载
+		hasMoreMessages: false,
+		messagesLoading: false,
+		__loadedMsgLimit: MSG_PAGE_SIZE,
 		// 历史懒加载
 		/** @type {{ sessionId: string, archivedAt: number }[]} */
 		historySessionIds: [],
@@ -83,6 +89,9 @@ export const useChatStore = defineStore('chat', {
 			this.topicMode = false;
 			this.topicAgentId = '';
 			this.currentSessionId = null;
+			this.hasMoreMessages = false;
+			this.messagesLoading = false;
+			this.__loadedMsgLimit = MSG_PAGE_SIZE;
 			this.historySessionIds = [];
 			this.historySegments = [];
 			this.historyLoading = false;
@@ -127,7 +136,10 @@ export const useChatStore = defineStore('chat', {
 			this.botId = String(botId || '');
 			this.chatSessionKey = '';
 			this.currentSessionId = null;
-			// topic 无历史上翻
+			// topic 无历史上翻、无分页
+			this.hasMoreMessages = false;
+			this.messagesLoading = false;
+			this.__loadedMsgLimit = MSG_PAGE_SIZE;
 			this.historySessionIds = [];
 			this.historySegments = [];
 			this.historyLoading = false;
@@ -178,18 +190,22 @@ export const useChatStore = defineStore('chat', {
 				this.errorText = '';
 			}
 			try {
-				// 通过 OC 原生 sessions.get 加载当前 session 消息
+				// 通过 OC 原生 sessions.get 加载当前 session 最近 N 条消息
+				const limit = MSG_PAGE_SIZE;
 				const result = await conn.request('sessions.get', {
 					key: this.chatSessionKey,
-					limit: 500,
+					limit,
 				});
 				const flatMsgs = Array.isArray(result?.messages) ? result.messages : [];
 				// 薄包装为 JSONL 行级结构（补 type + id）
 				this.messages = wrapOcMessages(flatMsgs);
+				this.__loadedMsgLimit = limit;
+				// sessions.get 返回 .slice(-limit)，若返回数 == limit 说明可能还有更多
+				this.hasMoreMessages = flatMsgs.length >= limit;
 				// 先解除 loading，使消息 DOM 在同一微任务内渲染，
 				// 确保 chatStore.messages watcher 触发的 scrollToBottom $nextTick 能看到可见的消息区域
 				this.loading = false;
-				console.debug('[chat] loadMessages ok count=%d', this.messages.length);
+				console.debug('[chat] loadMessages ok count=%d hasMore=%s', this.messages.length, this.hasMoreMessages);
 
 				// 获取当前 sessionId（用于历史上翻）
 				const hist = await conn.request('chat.history', {
@@ -210,6 +226,50 @@ export const useChatStore = defineStore('chat', {
 			}
 			finally {
 				this.loading = false; // 错误/异常时兜底
+			}
+		},
+
+		/**
+		 * 加载更早的消息（向上滚动时触发）
+		 * 利用 sessions.get 的 .slice(-limit) 语义，增大 limit 获取更多历史消息
+		 * @returns {Promise<boolean>} 是否成功加载了新消息
+		 */
+		async loadOlderMessages() {
+			if (!this.hasMoreMessages || this.messagesLoading) return false;
+			if (this.topicMode || !this.chatSessionKey) return false;
+
+			const conn = this.__getConnection();
+			if (!conn || conn.state !== 'connected') return false;
+
+			this.messagesLoading = true;
+			try {
+				const newLimit = this.__loadedMsgLimit + MSG_PAGE_SIZE;
+				const result = await conn.request('sessions.get', {
+					key: this.chatSessionKey,
+					limit: newLimit,
+				});
+				const flatMsgs = Array.isArray(result?.messages) ? result.messages : [];
+				const wrapped = wrapOcMessages(flatMsgs);
+
+				// 保留本地消息（streaming/乐观消息）
+				const localMsgs = this.messages.filter((m) => m._local);
+				const prevNonLocalCount = this.messages.length - localMsgs.length;
+
+				this.messages = [...wrapped, ...localMsgs];
+				this.__loadedMsgLimit = newLimit;
+				this.hasMoreMessages = flatMsgs.length >= newLimit;
+
+				const loaded = wrapped.length > prevNonLocalCount;
+				console.debug('[chat] loadOlderMessages limit=%d count=%d new=%d hasMore=%s',
+					newLimit, wrapped.length, wrapped.length - prevNonLocalCount, this.hasMoreMessages);
+				return loaded;
+			}
+			catch (err) {
+				console.warn('[chat] loadOlderMessages failed:', err?.message);
+				return false;
+			}
+			finally {
+				this.messagesLoading = false;
 			}
 		},
 
@@ -699,6 +759,9 @@ export const useChatStore = defineStore('chat', {
 			this.resetting = false;
 			this.topicMode = false;
 			this.topicAgentId = '';
+			this.hasMoreMessages = false;
+			this.messagesLoading = false;
+			this.__loadedMsgLimit = MSG_PAGE_SIZE;
 			this.historySessionIds = [];
 			this.historySegments = [];
 			this.historyLoading = false;

--- a/ui/src/stores/chat.store.test.js
+++ b/ui/src/stores/chat.store.test.js
@@ -2267,4 +2267,209 @@ describe('useChatStore', () => {
 			expect(store.sending).toBe(false);
 		});
 	});
+
+	// =====================================================================
+	// 渐进式消息加载（loadMessages limit + loadOlderMessages）
+	// =====================================================================
+
+	describe('progressive message loading', () => {
+		test('loadMessages 默认 limit 为 50', async () => {
+			const conn = mockConn();
+			setupConnForLoad(conn, { flatMessages: [] });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+
+			// sessions.get 调用应使用 limit=50
+			const sessCall = conn.request.mock.calls.find((c) => c[0] === 'sessions.get');
+			expect(sessCall).toBeTruthy();
+			expect(sessCall[1]).toMatchObject({ limit: 50 });
+		});
+
+		test('loadMessages: 返回数 < limit 时 hasMoreMessages=false', async () => {
+			const conn = mockConn();
+			const msgs = Array.from({ length: 10 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			setupConnForLoad(conn, { flatMessages: msgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+
+			expect(store.messages).toHaveLength(10);
+			expect(store.hasMoreMessages).toBe(false);
+		});
+
+		test('loadMessages: 返回数 >= limit 时 hasMoreMessages=true', async () => {
+			const conn = mockConn();
+			const msgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			setupConnForLoad(conn, { flatMessages: msgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+
+			expect(store.messages).toHaveLength(50);
+			expect(store.hasMoreMessages).toBe(true);
+		});
+
+		test('loadOlderMessages 增大 limit 向前加载并 prepend 到列表', async () => {
+			const conn = mockConn();
+			// 初始加载返回 50 条
+			const initialMsgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i + 50}` }));
+			setupConnForLoad(conn, { flatMessages: initialMsgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+			expect(store.hasMoreMessages).toBe(true);
+			expect(store.messages).toHaveLength(50);
+
+			// loadOlderMessages: 服务端返回更大范围（100 条 = 50 旧 + 50 原有）
+			const olderMsgs = Array.from({ length: 100 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') return Promise.resolve({ messages: olderMsgs });
+				return Promise.resolve(null);
+			});
+
+			const loaded = await store.loadOlderMessages();
+			expect(loaded).toBe(true);
+			expect(store.messages).toHaveLength(100);
+			// 请求应使用 limit=100（50 + 50）
+			const lastSessCall = conn.request.mock.calls.filter((c) => c[0] === 'sessions.get').pop();
+			expect(lastSessCall[1]).toMatchObject({ limit: 100 });
+		});
+
+		test('loadOlderMessages: 返回不足 limit 时 hasMoreMessages 设为 false', async () => {
+			const conn = mockConn();
+			const initialMsgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			setupConnForLoad(conn, { flatMessages: initialMsgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+			expect(store.hasMoreMessages).toBe(true);
+
+			// 再次加载时只返回 70 条（< 100），说明到头了
+			const allMsgs = Array.from({ length: 70 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') return Promise.resolve({ messages: allMsgs });
+				return Promise.resolve(null);
+			});
+
+			await store.loadOlderMessages();
+			expect(store.hasMoreMessages).toBe(false);
+			expect(store.messages).toHaveLength(70);
+		});
+
+		test('loadOlderMessages: hasMoreMessages=false 时不触发', async () => {
+			const conn = mockConn();
+			const msgs = [{ role: 'user', content: 'hi' }];
+			setupConnForLoad(conn, { flatMessages: msgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+			expect(store.hasMoreMessages).toBe(false);
+
+			const result = await store.loadOlderMessages();
+			expect(result).toBe(false);
+		});
+
+		test('loadOlderMessages: 保留本地 streaming 消息', async () => {
+			const conn = mockConn();
+			const initialMsgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			setupConnForLoad(conn, { flatMessages: initialMsgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+
+			// 模拟 streaming 中的本地消息
+			store.messages = [
+				...store.messages,
+				{ type: 'message', id: '__local_bot_1', _local: true, _streaming: true, message: { role: 'assistant', content: 'thinking...' } },
+			];
+
+			const olderMsgs = Array.from({ length: 80 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') return Promise.resolve({ messages: olderMsgs });
+				return Promise.resolve(null);
+			});
+
+			await store.loadOlderMessages();
+			// 80 条服务端消息 + 1 条本地消息
+			expect(store.messages).toHaveLength(81);
+			const localMsg = store.messages.find((m) => m._local);
+			expect(localMsg).toBeTruthy();
+			expect(localMsg.id).toBe('__local_bot_1');
+		});
+
+		test('loadOlderMessages: topic 模式下不触发', async () => {
+			const conn = mockConn();
+			conn.request.mockImplementation((method) => {
+				if (method === 'coclaw.sessions.getById') return Promise.resolve({ messages: [{ role: 'user', content: 'hi' }] });
+				return Promise.resolve(null);
+			});
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateTopic('topic-1', { botId: '1', agentId: 'main' });
+
+			const result = await store.loadOlderMessages();
+			expect(result).toBe(false);
+		});
+
+		test('loadOlderMessages: 并发防护', async () => {
+			const conn = mockConn();
+			const initialMsgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			setupConnForLoad(conn, { flatMessages: initialMsgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+
+			let resolveRequest;
+			conn.request.mockImplementation((method) => {
+				if (method === 'sessions.get') {
+					return new Promise((resolve) => { resolveRequest = resolve; });
+				}
+				return Promise.resolve(null);
+			});
+
+			// 同时触发两次
+			const p1 = store.loadOlderMessages();
+			const p2 = store.loadOlderMessages();
+
+			expect(store.messagesLoading).toBe(true);
+
+			// 第二次应立即返回 false（被 messagesLoading 拦截）
+			expect(await p2).toBe(false);
+
+			// 完成第一次
+			const allMsgs = Array.from({ length: 100 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			resolveRequest({ messages: allMsgs });
+			expect(await p1).toBe(true);
+			expect(store.messagesLoading).toBe(false);
+		});
+
+		test('activateSession 重置分页状态', async () => {
+			const conn = mockConn();
+			const msgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
+			setupConnForLoad(conn, { flatMessages: msgs });
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			await store.activateSession('1', 'main');
+			expect(store.hasMoreMessages).toBe(true);
+
+			// 切换到新 session（无消息）
+			setupConnForLoad(conn, { flatMessages: [] });
+			await store.activateSession('2', 'main', { force: true });
+			mockConnections.set('2', conn);
+
+			expect(store.hasMoreMessages).toBe(false);
+			expect(store.messagesLoading).toBe(false);
+		});
+	});
 });

--- a/ui/src/views/ChatPage.vue
+++ b/ui/src/views/ChatPage.vue
@@ -44,8 +44,12 @@
 				<div v-else-if="awaitingAgent" class="px-4 py-8 text-center text-sm text-muted">
 					{{ $t('chat.connecting') }}
 				</div>
+				<!-- 消息分页加载状态提示 -->
+				<div v-if="chatStore.messagesLoading" class="px-4 py-3 text-center text-xs text-muted">
+					{{ $t('chat.loading') }}
+				</div>
 				<!-- 历史加载状态提示 -->
-				<div v-if="chatStore.historyLoading" class="px-4 py-3 text-center text-xs text-muted">
+				<div v-else-if="chatStore.historyLoading" class="px-4 py-3 text-center text-xs text-muted">
 					{{ $t('chat.loading') }}
 				</div>
 				<div v-else-if="showNoMoreHint" class="px-4 pt-3 pb-2 text-center text-xs text-muted">
@@ -250,6 +254,8 @@ export default {
 		/** 是否还有未加载的更早历史 session */
 		hasMoreHistory() {
 			if (this.isTopicRoute) return false;
+			// 当前 session 还有更早消息，或有历史 session 可加载
+			if (this.chatStore.hasMoreMessages) return true;
 			return !this.chatStore.historyExhausted
 				&& this.chatStore.historySessionIds.length > 0
 				&& !this.chatStore.loading;
@@ -634,6 +640,21 @@ export default {
 		},
 
 		async __loadMoreHistory() {
+			// 优先加载当前 session 内的更早消息
+			if (this.chatStore.hasMoreMessages && !this.chatStore.messagesLoading) {
+				const el = this.$refs.scrollContainer;
+				const prevHeight = el?.scrollHeight ?? 0;
+				const loaded = await this.chatStore.loadOlderMessages();
+				if (loaded && el) {
+					// 保持滚动位置（新内容 prepend 后 scrollHeight 增加）
+					this.$nextTick(() => {
+						const newHeight = el.scrollHeight;
+						el.scrollTop += (newHeight - prevHeight);
+					});
+				}
+				return;
+			}
+
 			if (this.chatStore.historyExhausted || this.chatStore.historyLoading) {
 				if (this.chatStore.historyExhausted && !this.isTopicRoute && this.userScrolledUp) {
 					this.showNoMoreHint = true;


### PR DESCRIPTION
### 改动内容

将消息加载默认数量从 500 条降为 50 条，实现向上滚动分页加载历史消息。

### 原因

Closes #50

对话越长加载越慢，一次性加载 500 条消息严重影响体验。

### 改动范围

- `ui/src/stores/chat.store.js`：
  - `MSG_PAGE_SIZE = 50`，`loadMessages` 默认 limit 改为 50
  - 新增 `loadOlderMessages()` 方法（每次增加 PAGE_SIZE）
  - 新增 `hasMoreMessages` / `messagesLoading` 状态
  - 并发保护 + 保留 streaming 消息
- `ui/src/stores/chat.store.test.js`：新增渐进式加载相关测试
- `ui/src/views/ChatPage.vue`：滚动到顶部触发加载 + 保持滚动位置

### 测试说明

- UI 全量: 828/828 ✅

### 如何验证

1. 打开一个有大量历史消息的对话
2. 初始只加载最近 50 条，加载速度明显提升
3. 向上滚动 → 触发加载更早的消息
4. 加载完成后滚动位置不跳
5. 所有历史消息加载完毕后不再触发加载

— [CoClaw Team](https://github.com/coclaw)