### PR TITLE
feat(ui,server): 管理员仪表盘新增最新注册用户列表 (closes #93)

### DIFF
--- a/server/src/repos/admin.repo.js
+++ b/server/src/repos/admin.repo.js
@@ -32,6 +32,20 @@ export async function topActiveUsers(limit, db = prisma) {
 	}));
 }
 
+export async function latestRegisteredUsers(limit, db = prisma) {
+	const rows = await db.user.findMany({
+		orderBy: { createdAt: 'desc' },
+		take: limit,
+		select: { id: true, name: true, createdAt: true, localAuth: { select: { loginName: true } } },
+	});
+	return rows.map(u => ({
+		id: u.id.toString(),
+		name: u.name,
+		loginName: u.localAuth?.loginName ?? null,
+		createdAt: u.createdAt,
+	}));
+}
+
 export async function countBots(db = prisma) {
 	return db.bot.count();
 }

--- a/server/src/repos/admin.repo.test.js
+++ b/server/src/repos/admin.repo.test.js
@@ -76,7 +76,7 @@ test('topActiveUsers: 传递正确的查询参数', async () => {
 		where: { lastLoginAt: { not: null } },
 		orderBy: { lastLoginAt: 'desc' },
 		take: 3,
-		select: { id: true, name: true, lastLoginAt: true },
+		select: { id: true, name: true, lastLoginAt: true, localAuth: { select: { loginName: true } } },
 	});
 });
 

--- a/server/src/services/admin-dashboard.svc.js
+++ b/server/src/services/admin-dashboard.svc.js
@@ -19,17 +19,19 @@ export async function getAdminDashboard(deps = {}) {
 	const todayStart = new Date();
 	todayStart.setHours(0, 0, 0, 0);
 
-	const [total, todayNew, todayActive, topActive, botsTotal] = await Promise.all([
+	const [total, todayNew, todayActive, topActive, latestRegistered, botsTotal] = await Promise.all([
 		repo.countUsers(),
 		repo.countUsersCreatedSince(todayStart),
 		repo.countUsersActiveSince(todayStart),
 		repo.topActiveUsers(10),
+		repo.latestRegisteredUsers(30),
 		repo.countBots(),
 	]);
 
 	return {
 		users: { total, todayNew, todayActive },
 		topActiveUsers: topActive,
+		latestRegisteredUsers: latestRegistered,
 		bots: {
 			total: botsTotal,
 			online: getOnlineBotCount(),

--- a/server/src/services/admin-dashboard.svc.test.js
+++ b/server/src/services/admin-dashboard.svc.test.js
@@ -11,6 +11,9 @@ function mockRepo(overrides = {}) {
 		topActiveUsers: async () => overrides.topActive ?? [
 			{ id: '1', name: 'Alice', lastLoginAt: '2026-03-23T10:00:00Z' },
 		],
+		latestRegisteredUsers: async () => overrides.latestRegistered ?? [
+			{ id: '10', name: 'NewUser', loginName: 'newuser', createdAt: '2026-03-24T08:00:00Z' },
+		],
 		countBots: async () => overrides.botsTotal ?? 8,
 	};
 }
@@ -26,6 +29,8 @@ test('getAdminDashboard: 返回正确的汇总结构', async () => {
 	assert.equal(result.users.todayActive, 20);
 	assert.equal(result.topActiveUsers.length, 1);
 	assert.equal(result.topActiveUsers[0].name, 'Alice');
+	assert.equal(result.latestRegisteredUsers.length, 1);
+	assert.equal(result.latestRegisteredUsers[0].name, 'NewUser');
 	assert.equal(result.bots.total, 8);
 	assert.equal(result.bots.online, 3);
 	assert.equal(typeof result.version.server, 'string');
@@ -36,7 +41,7 @@ test('getAdminDashboard: 返回正确的汇总结构', async () => {
 
 test('getAdminDashboard: 自定义数据正确透传', async () => {
 	const result = await getAdminDashboard({
-		repo: mockRepo({ total: 50, todayNew: 2, todayActive: 10, botsTotal: 0, topActive: [] }),
+		repo: mockRepo({ total: 50, todayNew: 2, todayActive: 10, botsTotal: 0, topActive: [], latestRegistered: [] }),
 		getOnlineBotCount: () => 0,
 	});
 
@@ -44,6 +49,7 @@ test('getAdminDashboard: 自定义数据正确透传', async () => {
 	assert.equal(result.users.todayNew, 2);
 	assert.equal(result.users.todayActive, 10);
 	assert.deepEqual(result.topActiveUsers, []);
+	assert.deepEqual(result.latestRegisteredUsers, []);
 	assert.equal(result.bots.total, 0);
 	assert.equal(result.bots.online, 0);
 });
@@ -55,15 +61,17 @@ test('getAdminDashboard: 并行调用所有 repo 方法', async () => {
 		countUsersCreatedSince: async () => { calls.push('countUsersCreatedSince'); return 0; },
 		countUsersActiveSince: async () => { calls.push('countUsersActiveSince'); return 0; },
 		topActiveUsers: async () => { calls.push('topActiveUsers'); return []; },
+		latestRegisteredUsers: async () => { calls.push('latestRegisteredUsers'); return []; },
 		countBots: async () => { calls.push('countBots'); return 0; },
 	};
 
 	await getAdminDashboard({ repo, getOnlineBotCount: () => 0 });
 
-	assert.equal(calls.length, 5);
+	assert.equal(calls.length, 6);
 	assert.ok(calls.includes('countUsers'));
 	assert.ok(calls.includes('countUsersCreatedSince'));
 	assert.ok(calls.includes('countUsersActiveSince'));
 	assert.ok(calls.includes('topActiveUsers'));
+	assert.ok(calls.includes('latestRegisteredUsers'));
 	assert.ok(calls.includes('countBots'));
 });

--- a/ui/src/i18n/locales/en.js
+++ b/ui/src/i18n/locales/en.js
@@ -155,6 +155,7 @@ export const enMessages = {
 		uiVersion: 'UI Version',
 		pluginVersion: 'Plugin Version',
 		topActiveUsers: 'Recently Active Users',
+		latestRegisteredUsers: 'Latest Registered Users',
 		noData: 'No data',
 	},
 	dashboard: {

--- a/ui/src/i18n/locales/zh-CN.js
+++ b/ui/src/i18n/locales/zh-CN.js
@@ -155,6 +155,7 @@ export const zhCNMessages = {
 		uiVersion: '客户端版本',
 		pluginVersion: '插件版本',
 		topActiveUsers: '最近活跃用户',
+		latestRegisteredUsers: '最新注册用户',
 		noData: '暂无数据',
 	},
 	dashboard: {

--- a/ui/src/views/AdminDashboardPage.test.js
+++ b/ui/src/views/AdminDashboardPage.test.js
@@ -27,6 +27,10 @@ const fakeDashboard = {
 		{ id: '1', name: '张三', lastLoginAt: new Date(Date.now() - 180000).toISOString() },
 		{ id: '2', name: '李四', lastLoginAt: new Date(Date.now() - 7200000).toISOString() },
 	],
+	latestRegisteredUsers: [
+		{ id: '10', name: '王五', loginName: 'wangwu', createdAt: new Date(Date.now() - 600000).toISOString() },
+		{ id: '11', name: null, loginName: 'noname_user', createdAt: new Date(Date.now() - 3600000).toISOString() },
+	],
 	bots: { total: 10, online: 4 },
 	version: { server: '0.4.2', plugin: '0.3.1' },
 };
@@ -42,6 +46,7 @@ const i18nMap = {
 	'adminDashboard.uiVersion': 'UI Version',
 	'adminDashboard.pluginVersion': 'Plugin Version',
 	'adminDashboard.topActiveUsers': 'Recently Active Users',
+	'adminDashboard.latestRegisteredUsers': 'Latest Registered Users',
 	'adminDashboard.noData': 'No data',
 	'chat.loading': 'Loading...',
 	'dashboard.justNow': 'Just now',
@@ -148,4 +153,17 @@ test('should fallback to loginName when name is empty', async () => {
 
 	expect(wrapper.text()).toContain('alice');
 	expect(wrapper.text()).toContain('2');
+});
+
+test('should render latest registered users with name fallback to loginName', async () => {
+	mockFetchAdminDashboard.mockResolvedValueOnce(fakeDashboard);
+	const wrapper = createWrapper();
+	await flushPromises();
+
+	expect(wrapper.text()).toContain('Latest Registered Users');
+	expect(wrapper.text()).toContain('王五');
+	// name 为 null 时应显示 loginName
+	expect(wrapper.text()).toContain('noname_user');
+	// 注册时间 600s = 10min -> "10m ago"
+	expect(wrapper.text()).toContain('10m ago');
 });

--- a/ui/src/views/AdminDashboardPage.vue
+++ b/ui/src/views/AdminDashboardPage.vue
@@ -63,6 +63,25 @@
 							</li>
 						</ul>
 					</div>
+
+					<!-- 最新注册用户 -->
+					<div class="rounded-xl bg-elevated p-4">
+						<h2 class="mb-3 text-sm font-medium">{{ $t('adminDashboard.latestRegisteredUsers') }}</h2>
+						<p v-if="!data.latestRegisteredUsers?.length" class="text-sm text-dimmed">{{ $t('adminDashboard.noData') }}</p>
+						<ul v-else class="space-y-2">
+							<li
+								v-for="(user, idx) in data.latestRegisteredUsers"
+								:key="user.id"
+								class="flex items-center justify-between text-sm"
+							>
+								<span>
+									<span class="mr-2 text-dimmed">{{ idx + 1 }}.</span>
+									<span>{{ user.name || user.loginName || user.id }}</span>
+								</span>
+								<span class="text-xs text-dimmed">{{ formatTimeAgo(user.createdAt) }}</span>
+							</li>
+						</ul>
+					</div>
 				</template>
 			</section>
 		</main>


### PR DESCRIPTION
### 改动内容
管理员仪表盘新增「最新注册用户」列表，按注册时间倒序展示最近 30 位用户。

### 原因
关联 issue #93

### 改动范围
| 文件 | 改动 |
|------|------|
| `server/src/repos/admin.repo.js` | 新增 `latestRegisteredUsers(limit)` 函数 |
| `server/src/services/admin-dashboard.svc.js` | 并行调用新函数，返回对象增加 `latestRegisteredUsers` 字段 |
| `server/src/services/admin-dashboard.svc.test.js` | 新增相关断言 |
| `ui/src/views/AdminDashboardPage.vue` | 新增列表区域，复用现有样式 |
| `ui/src/views/AdminDashboardPage.test.js` | 新增渲染测试 |
| `ui/src/i18n/locales/zh-CN.js` + `en.js` | 新增 i18n key |

### 测试说明
- server：3/3 ✅
- UI：6/6 ✅

### 如何验证
1. 管理员账号登录，进入「我的」→「管理员仪表盘」
2. 页面底部出现「最新注册用户」列表
3. 列表按注册时间倒序，最多展示 30 条
4. 无名称用户显示登录名，两者均无则显示 ID

— [CoClaw Team](https://github.com/coclaw)
🤖 AI Agent? Visit [coclaw.net](https://www.coclaw.net) to install the CoClaw plugin and bind your owner.