### PR TITLE
fix(ui): 移除实例概览卡片中的频道连接状态显示 (closes #103)

### DIFF
--- a/ui/src/components/dashboard/InstanceOverview.test.js
+++ b/ui/src/components/dashboard/InstanceOverview.test.js
@@ -69,15 +69,6 @@ describe('InstanceOverview', () => {
 		expect(wrapper.text()).toContain('2.0');
 	});
 
-	test('displays channel status icons with channel names', () => {
-		const wrapper = mountOverview({
-			instance: { name: 'Bot', online: true, channels: [{ id: 'discord', connected: true }, { id: 'slack', connected: false }] },
-		});
-		expect(wrapper.text()).toContain('✅');
-		expect(wrapper.text()).toContain('❌');
-		expect(wrapper.text()).toContain('discord');
-		expect(wrapper.text()).toContain('slack');
-	});
 
 	test('displays agent count', () => {
 		const wrapper = mountOverview({

--- a/ui/src/components/dashboard/InstanceOverview.vue
+++ b/ui/src/components/dashboard/InstanceOverview.vue
@@ -14,16 +14,10 @@
 				<p class="text-xs text-muted">{{ $t('dashboard.monthlyCost') }}</p>
 			</div>
 		</div>
-		<!-- 版本 + 频道状态 + agent 数 -->
+		<!-- 版本 + agent 数 -->
 		<div class="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted">
 			<span v-if="instance.pluginVersion">{{ $t('bots.pluginVersion') }}{{ instance.pluginVersion }}</span>
 			<span v-if="instance.clawVersion">{{ $t('bots.clawVersion') }}{{ instance.clawVersion }}</span>
-			<span v-if="instance.channels?.length" class="flex items-center gap-1.5">
-				<span v-for="ch in instance.channels" :key="ch.id" class="inline-flex items-center gap-0.5" :title="ch.id">
-					<span class="text-[10px]">{{ ch.connected ? '✅' : '❌' }}</span>
-					<span>{{ ch.id }}</span>
-				</span>
-			</span>
 			<UBadge color="primary" variant="subtle" size="xs">{{ agentCount }} {{ $t('dashboard.agents') }}</UBadge>
 		</div>
 	</div>

--- a/ui/src/stores/dashboard.store.js
+++ b/ui/src/stores/dashboard.store.js
@@ -20,7 +20,6 @@ import { generateModelTags } from '../utils/model-tags.js';
  *   pluginVersion: string|null,
  *   clawVersion: string|null,
  *   monthlyCost: object|null,
- *   channels: { id: string, connected: boolean }[],
  *   model: string|null,
  *   provider: string|null,
  * }} DashboardInstance
@@ -42,23 +41,6 @@ import { generateModelTags } from '../utils/model-tags.js';
 // =====================================================================
 // 辅助函数（模块内部）
 // =====================================================================
-
-/**
- * 从 channels.status 响应构建频道列表
- * @param {object|null} channelsData
- * @returns {{ id: string, connected: boolean }[]}
- */
-function buildChannelList(channelsData) {
-	if (!channelsData || typeof channelsData !== 'object') return [];
-	return Object.entries(channelsData)
-		.filter(([key]) => key !== 'defaultAccountId')
-		.map(([id, data]) => ({
-			id,
-			connected: Array.isArray(data?.accounts)
-				? data.accounts.some(a => a.enabled !== false)
-				: false,
-		}));
-}
 
 /**
  * 从 tools.catalog 响应提取工具 ID 列表
@@ -172,7 +154,6 @@ export const useDashboardStore = defineStore('dashboard', {
 					usageCostResult,
 					sessionsResult,
 					ttsResult,
-					channelsResult,
 					...toolResults
 				] = await Promise.allSettled([
 					conn.request('status', {}),
@@ -180,7 +161,6 @@ export const useDashboardStore = defineStore('dashboard', {
 					conn.request('usage.cost', { mode: 'month' }),
 					conn.request('sessions.list', {}),
 					conn.request('tts.status', {}),
-					conn.request('channels.status', { probe: false }),
 					...agentList.map(agent =>
 						conn.request('tools.catalog', { agentId: agent.id })
 					),
@@ -192,7 +172,6 @@ export const useDashboardStore = defineStore('dashboard', {
 				const usageCost = usageCostResult.status === 'fulfilled' ? usageCostResult.value : null;
 				const sessions = sessionsResult.status === 'fulfilled' ? sessionsResult.value : null;
 				const tts = ttsResult.status === 'fulfilled' ? ttsResult.value : null;
-				const channels = channelsResult.status === 'fulfilled' ? channelsResult.value : null;
 
 				// 构建实例总览
 				const botsStore = useBotsStore();
@@ -205,7 +184,6 @@ export const useDashboardStore = defineStore('dashboard', {
 					pluginVersion: pluginInfo.version ?? null,
 					clawVersion: pluginInfo.clawVersion ?? null,
 					monthlyCost: usageCost,
-					channels: buildChannelList(channels),
 					model: status?.model ?? null,
 					provider: status?.provider ?? null,
 				};
@@ -265,7 +243,6 @@ export const useDashboardStore = defineStore('dashboard', {
 
 /** @internal 仅供测试访问内部函数 */
 export const __test__ = {
-	buildChannelList,
 	extractToolIds,
 	findCurrentModel,
 	filterSessionsByAgent,

--- a/ui/src/stores/dashboard.store.test.js
+++ b/ui/src/stores/dashboard.store.test.js
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { useDashboardStore, __test__ } from './dashboard.store.js';
 
 const {
-	buildChannelList,
 	extractToolIds,
 	findCurrentModel,
 	filterSessionsByAgent,
@@ -40,44 +39,6 @@ import { useAgentsStore } from './agents.store.js';
 // =====================================================================
 
 describe('dashboard store helpers', () => {
-	// -----------------------------------------------------------------
-	// buildChannelList
-	// -----------------------------------------------------------------
-	describe('buildChannelList', () => {
-		test('正常数据返回频道列表', () => {
-			const data = {
-				defaultAccountId: 'acc-1',
-				discord: { accounts: [{ enabled: true }] },
-				slack: { accounts: [{ enabled: false }] },
-			};
-			const result = buildChannelList(data);
-			expect(result).toEqual([
-				{ id: 'discord', connected: true },
-				{ id: 'slack', connected: false },
-			]);
-		});
-
-		test('account 无 enabled 字段视为启用', () => {
-			const data = { telegram: { accounts: [{}] } };
-			const result = buildChannelList(data);
-			expect(result).toEqual([{ id: 'telegram', connected: true }]);
-		});
-
-		test('空数据返回空数组', () => {
-			expect(buildChannelList({})).toEqual([]);
-		});
-
-		test('null 返回空数组', () => {
-			expect(buildChannelList(null)).toEqual([]);
-		});
-
-		test('accounts 非数组时 connected 为 false', () => {
-			const data = { web: { accounts: 'invalid' } };
-			const result = buildChannelList(data);
-			expect(result).toEqual([{ id: 'web', connected: false }]);
-		});
-	});
-
 	// -----------------------------------------------------------------
 	// extractToolIds
 	// -----------------------------------------------------------------
@@ -290,10 +251,6 @@ describe('dashboard store', () => {
 				],
 			},
 			'tts.status': { enabled: true },
-			'channels.status': {
-				defaultAccountId: 'acc-1',
-				discord: { accounts: [{ enabled: true }] },
-			},
 			'tools.catalog': {
 				groups: [{ tools: [{ id: 'web_search' }, { id: 'read' }] }],
 			},
@@ -313,7 +270,6 @@ describe('dashboard store', () => {
 		expect(entry.instance.pluginVersion).toBe('0.3.0');
 		expect(entry.instance.clawVersion).toBe('0.7.0');
 		expect(entry.instance.monthlyCost).toEqual({ total: 12.5, currency: 'USD' });
-		expect(entry.instance.channels).toEqual([{ id: 'discord', connected: true }]);
 		expect(entry.instance.model).toBe('claude-3');
 		expect(entry.instance.provider).toBe('anthropic');
 
@@ -353,7 +309,6 @@ describe('dashboard store', () => {
 			'usage.cost': new Error('rpc timeout'),
 			'sessions.list': new Error('not available'),
 			'tts.status': new Error('not supported'),
-			'channels.status': new Error('failed'),
 			'tools.catalog': new Error('catalog error'),
 		});
 		mockConnections.set('bot-1', dashConn);
@@ -367,7 +322,6 @@ describe('dashboard store', () => {
 
 		// 失败的 RPC 产出 null/空值
 		expect(entry.instance.monthlyCost).toBeNull();
-		expect(entry.instance.channels).toEqual([]);
 		expect(entry.instance.model).toBe('gpt-4');
 
 		// agent 能力为空（tools.catalog 失败）
@@ -450,7 +404,6 @@ describe('dashboard store', () => {
 			'usage.cost': null,
 			'sessions.list': { sessions: [] },
 			'tts.status': {},
-			'channels.status': {},
 			'tools.catalog': { groups: [] },
 		});
 		mockConnections.set('42', dashConn);
@@ -480,7 +433,6 @@ describe('dashboard store', () => {
 			'usage.cost': null,
 			'sessions.list': { sessions: [] },
 			'tts.status': {},
-			'channels.status': {},
 			'tools.catalog': { groups: [] },
 		});
 		mockConnections.set('bot-1', dashConn);


### PR DESCRIPTION
### 改动内容

移除 AgentCard 实例概览卡片中展示频道连接状态的区块，简化卡片内容。

### 原因

Closes #103

### 测试说明

ui 全量测试通过

— [CoClaw Team](https://github.com/coclaw)
🤖 AI Agent? Visit [coclaw.net](https://www.coclaw.net) to install the CoClaw plugin and bind your owner.