### PR TITLE
fix(ui): 加载历史消息时防止窗口跳回底部 (closes #105)

### DIFF
--- a/ui/src/views/ChatPage.vue
+++ b/ui/src/views/ChatPage.vue
@@ -158,6 +158,8 @@ export default {
 			__isFirstRound: false,
 			// 新建 topic 流程进行中，抑制 watcher 的重复激活
 			__creatingTopic: false,
+			// 历史加载中，抑制 messages watcher 的 scrollToBottom
+			__loadingHistory: false,
 		};
 	},
 	computed: {
@@ -358,7 +360,9 @@ export default {
 			}
 		},
 		'chatStore.messages'() {
-			this.scrollToBottom();
+			if (!this.__loadingHistory) {
+				this.scrollToBottom();
+			}
 		},
 	},
 	beforeUnmount() {
@@ -661,13 +665,17 @@ export default {
 			if (this.chatStore.hasMoreMessages && !this.chatStore.messagesLoading) {
 				const el = this.$refs.scrollContainer;
 				const prevHeight = el?.scrollHeight ?? 0;
+				this.__loadingHistory = true;
 				const loaded = await this.chatStore.loadOlderMessages();
 				if (loaded && el) {
 					// 保持滚动位置（新内容 prepend 后 scrollHeight 增加）
 					this.$nextTick(() => {
 						const newHeight = el.scrollHeight;
 						el.scrollTop += (newHeight - prevHeight);
+						this.__loadingHistory = false;
 					});
+				} else {
+					this.__loadingHistory = false;
 				}
 				return;
 			}
@@ -680,13 +688,17 @@ export default {
 			}
 			const el = this.$refs.scrollContainer;
 			const prevHeight = el?.scrollHeight ?? 0;
+			this.__loadingHistory = true;
 			const loaded = await this.chatStore.loadNextHistorySession();
 			if (loaded && el) {
 				// 保持滚动位置（新内容 prepend 后 scrollHeight 增加）
 				this.$nextTick(() => {
 					const newHeight = el.scrollHeight;
 					el.scrollTop += (newHeight - prevHeight);
+					this.__loadingHistory = false;
 				});
+			} else {
+				this.__loadingHistory = false;
 			}
 			// 刚加载完最后一段历史后也显示提示
 			if (this.chatStore.historyExhausted && !this.isTopicRoute && this.userScrolledUp) {


### PR DESCRIPTION
### 改动内容

修复历史消息加载触发时，messages watcher 无条件调用 scrollToBottom 导致窗口跳回底部的问题。

### 原因

Closes #105

### 测试说明

ui 全量测试通过

— [CoClaw Team](https://github.com/coclaw)
🤖 AI Agent? Visit [coclaw.net](https://www.coclaw.net) to install the CoClaw plugin and bind your owner.