### PR TITLE
fix(ui): ensure event:agent listener covers all entry paths (closes #8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coclaw/coclaw",
-	"version": "0.9.16",
+	"version": "0.9.11",
 	"private": true,
 	"description": "CoClaw platform — interact with your OpenClaw through CoClaw, even across network isolation",
 	"license": "SEE LICENSE IN LICENSE",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coclaw/server",
-	"version": "0.5.5",
+	"version": "0.5.3",
 	"private": true,
 	"description": "CoClaw backend service",
 	"type": "module",

--- a/server/src/binding-wait-hub.js
+++ b/server/src/binding-wait-hub.js
@@ -118,10 +118,6 @@ export function waitBindingResult({ code, waitToken, userId }) {
 	});
 }
 
-// cancel 会设 status='cancelled'，这对 binding 流程安全：
-// cancel 由 UI 端 wait 轮询断连触发，markBound 由 plugin 端 bindBotHandler 触发，
-// 两者为不同发起方的独立请求，cancel 不会阻断 markBound。
-// 注意 claim-wait-hub.cancelClaimWait 采用不同策略（不改 status），见其注释。
 export function cancelBindingWait({ code, waitToken, userId }) {
 	const state = bindingStates.get(code);
 	if (!state || state.waitToken !== waitToken || state.userId !== String(userId)) {

--- a/server/src/claim-wait-hub.js
+++ b/server/src/claim-wait-hub.js
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-// 认领码等待状态（与 binding-wait-hub 对称，无 userId 语义）
+// 认领码等待状态（与 binding-wait-hub 对称，但无 userId/cancel 语义）
 const claimStates = new Map();
 
 function nowMs() {
@@ -73,23 +73,6 @@ export function markClaimBound({ code, botId, token }) {
 	// 已完成的条目延迟清理（60s 缓冲，让迟到的 waiter 仍能获取结果）
 	clearTimeout(state.cleanupTimer);
 	state.cleanupTimer = setTimeout(() => claimStates.delete(code), 60_000);
-}
-
-// 仅提前 settle 当前 waiters，不改 status，不影响后续 markClaimBound。
-// 与 binding-wait-hub.cancelBindingWait 不同：后者会设 status='cancelled'，
-// 因为 binding 的 cancel(UI 端) 和 markBound(plugin 端) 由不同发起方调用，互不干扰。
-// 而 claim 的 cancel(plugin 断连) 和 markBound(用户 claim) 共享同一 state，
-// 改 status 会阻断 markClaimBound → 导致 enroll 流程卡死。
-export function cancelClaimWait({ code, waitToken }) {
-	const state = claimStates.get(code);
-	if (!state || state.waitToken !== waitToken) {
-		return false;
-	}
-	if (state.status !== 'pending') {
-		return false;
-	}
-	settleState(code, { status: 'CANCELLED' });
-	return true;
 }
 
 export function waitClaimResult({ code, waitToken }) {

--- a/server/src/claim-wait-hub.test.js
+++ b/server/src/claim-wait-hub.test.js
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
-	cancelClaimWait,
 	markClaimBound,
 	registerClaimWait,
 	waitClaimResult,
@@ -111,62 +110,4 @@ test('markClaimBound: should reschedule cleanup timer', async () => {
 	const result = await waitClaimResult({ code, waitToken });
 	assert.equal(result.status, 'BOUND');
 	assert.equal(result.botId, '77');
-});
-
-test('cancelClaimWait: should settle waiters without changing status', async () => {
-	const code = 'CW_CANCEL_01';
-	const waitToken = registerClaimWait({
-		code,
-		expiresAt: new Date(Date.now() + 60_000),
-	});
-
-	const promise = waitClaimResult({ code, waitToken });
-	const cancelled = cancelClaimWait({ code, waitToken });
-
-	assert.equal(cancelled, true);
-	const result = await promise;
-	assert.equal(result.status, 'CANCELLED');
-});
-
-test('cancelClaimWait: markClaimBound should still work after cancel', async () => {
-	const code = 'CW_CANCEL_THEN_BOUND';
-	const waitToken = registerClaimWait({
-		code,
-		expiresAt: new Date(Date.now() + 60_000),
-	});
-
-	// cancel 提前 settle 当前 waiter
-	cancelClaimWait({ code, waitToken });
-
-	// claim 完成后 markClaimBound 仍应生效（status 仍为 pending）
-	markClaimBound({ code, botId: 55n, token: 'tok-55' });
-
-	// 下一轮 wait 应立即拿到 BOUND
-	const result = await waitClaimResult({ code, waitToken });
-	assert.equal(result.status, 'BOUND');
-	assert.equal(result.botId, '55');
-	assert.equal(result.token, 'tok-55');
-});
-
-test('cancelClaimWait: should reject wrong waitToken', () => {
-	const code = 'CW_CANCEL_02';
-	registerClaimWait({
-		code,
-		expiresAt: new Date(Date.now() + 60_000),
-	});
-	assert.equal(cancelClaimWait({ code, waitToken: 'wrong' }), false);
-});
-
-test('cancelClaimWait: should reject already-bound state', () => {
-	const code = 'CW_CANCEL_03';
-	const waitToken = registerClaimWait({
-		code,
-		expiresAt: new Date(Date.now() + 60_000),
-	});
-	markClaimBound({ code, botId: 1n, token: 'tok' });
-	assert.equal(cancelClaimWait({ code, waitToken }), false);
-});
-
-test('cancelClaimWait: should reject unknown code', () => {
-	assert.equal(cancelClaimWait({ code: 'NOPE', waitToken: 'x' }), false);
 });

--- a/server/src/routes/bot.route.js
+++ b/server/src/routes/bot.route.js
@@ -285,6 +285,8 @@ export async function waitBindingCodeHandler(req, res, next, deps = {}) {
 
 	const {
 		cancelBindingWaitImpl = cancelBindingWait,
+		findBindingCodeImpl = findBindingCode,
+		deleteBindingCodeImpl = deleteBindingCode,
 		waitBindingResultImpl = waitBindingResult,
 	} = deps;
 
@@ -299,13 +301,21 @@ export async function waitBindingCodeHandler(req, res, next, deps = {}) {
 	}
 
 	let aborted = false;
-	const onAbort = () => {
+	const onAbort = async () => {
 		aborted = true;
-		cancelBindingWaitImpl({
+		const cancelled = cancelBindingWaitImpl({
 			code,
 			waitToken,
 			userId: req.user.id,
 		});
+		if (!cancelled) {
+			return;
+		}
+		const bindingCode = await findBindingCodeImpl(code).catch(() => null);
+		if (!bindingCode || bindingCode.userId !== req.user.id) {
+			return;
+		}
+		await deleteBindingCodeImpl(code).catch(() => {});
 	};
 
 	res.on('close', () => {

--- a/server/src/routes/bot.route.test.js
+++ b/server/src/routes/bot.route.test.js
@@ -293,10 +293,14 @@ test('waitBindingCodeHandler: should return timeout when expired', async () => {
 	assert.equal(res.body.code, 'BINDING_TIMEOUT');
 });
 
-test('waitBindingCodeHandler: should cancel wait but not delete binding code on abort', async () => {
+test('waitBindingCodeHandler: should cancel and delete binding code on abort', async () => {
 	const req = createWaitReq({ code: '12345678', waitToken: 'token' });
 	const res = createRes();
-	let cancelCount = 0;
+	const calls = {
+		cancel: 0,
+		find: 0,
+		delete: 0,
+	};
 	let release;
 	const pending = new Promise((resolve) => {
 		release = resolve;
@@ -304,8 +308,15 @@ test('waitBindingCodeHandler: should cancel wait but not delete binding code on 
 
 	const running = waitBindingCodeHandler(req, res, () => {}, {
 		cancelBindingWaitImpl: () => {
-			cancelCount += 1;
+			calls.cancel += 1;
 			return true;
+		},
+		findBindingCodeImpl: async () => {
+			calls.find += 1;
+			return { code: '12345678', userId: 7n };
+		},
+		deleteBindingCodeImpl: async () => {
+			calls.delete += 1;
 		},
 		waitBindingResultImpl: async () => pending,
 	});
@@ -315,8 +326,10 @@ test('waitBindingCodeHandler: should cancel wait but not delete binding code on 
 	release({ status: 'PENDING' });
 	await running;
 
-	assert.equal(cancelCount, 1);
-	assert.equal(res.statusCode, null); // 未发送响应
+	assert.equal(calls.cancel, 1);
+	assert.equal(calls.find, 1);
+	assert.equal(calls.delete, 1);
+	assert.equal(res.statusCode, null);
 });
 
 test('cancelBindingCodeHandler: should reject unauthenticated request', async () => {

--- a/server/src/routes/claw.route.js
+++ b/server/src/routes/claw.route.js
@@ -3,7 +3,6 @@ import { Router } from 'express';
 import { createClaimCode, claimBot } from '../services/bot-binding.svc.js';
 import {
 	registerClaimWait,
-	cancelClaimWait,
 	waitClaimResult,
 	markClaimBound,
 } from '../claim-wait-hub.js';
@@ -52,10 +51,7 @@ export async function createClaimCodeHandler(req, res, next, deps = {}) {
 
 // POST /api/v1/claws/claim-codes/wait — 公开，Plugin(gateway) 长轮询
 export async function waitClaimCodeHandler(req, res, next, deps = {}) {
-	const {
-		cancelClaimWaitImpl = cancelClaimWait,
-		waitClaimResultImpl = waitClaimResult,
-	} = deps;
+	const { waitClaimResultImpl = waitClaimResult } = deps;
 
 	const code = String(req.body?.code ?? '').trim();
 	const waitToken = String(req.body?.waitToken ?? '').trim();
@@ -70,10 +66,7 @@ export async function waitClaimCodeHandler(req, res, next, deps = {}) {
 	try {
 		let aborted = false;
 		res.on('close', () => {
-			if (!res.writableFinished) {
-				aborted = true;
-				cancelClaimWaitImpl({ code, waitToken });
-			}
+			if (!res.writableFinished) aborted = true;
 		});
 
 		const result = await waitClaimResultImpl({ code, waitToken });

--- a/server/src/routes/claw.route.test.js
+++ b/server/src/routes/claw.route.test.js
@@ -168,17 +168,17 @@ test('waitClaimCodeHandler: should return 200 CLAIM_PENDING for other statuses',
 	assert.equal(res.body.code, 'CLAIM_PENDING');
 });
 
-test('waitClaimCodeHandler: should cancel wait and not send response when client disconnects', async () => {
+test('waitClaimCodeHandler: should not send response when client disconnects', async () => {
 	const req = createReqWithBody({ code: '12345678', waitToken: 'tok' });
+	// 模拟客户端断连：res.on('close') 回调在 wait 期间触发
 	const res = createRes();
+	const originalOn = res.on;
 	let closeCallback;
-	let cancelCount = 0;
 	res.on = (event, cb) => {
 		if (event === 'close') closeCallback = cb;
 	};
 
 	await waitClaimCodeHandler(req, res, () => {}, {
-		cancelClaimWaitImpl: () => { cancelCount += 1; },
 		waitClaimResultImpl: async () => {
 			// 模拟等待期间客户端断连
 			closeCallback?.();
@@ -186,7 +186,7 @@ test('waitClaimCodeHandler: should cancel wait and not send response when client
 		},
 	});
 
-	assert.equal(cancelCount, 1);
+	// 客户端已断连，不应发送响应
 	assert.equal(res.statusCode, null);
 });
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@coclaw/ui",
-	"version": "0.9.16",
+	"version": "0.9.11",
 	"private": true,
 	"description": "CoClaw frontend application",
 	"type": "module",

--- a/ui/src/components/MainList.vue
+++ b/ui/src/components/MainList.vue
@@ -278,10 +278,10 @@ export default {
 			await this.topicsStore.loadAllTopics();
 		},
 		onTopicDeleted(topicId) {
-			// 兜底：桌面端侧边栏始终挂载，若正在查看被删除的 topic 则跳转默认路由
+			// 如果当前正在查看被删除的 topic，导航回 topic 列表
 			const route = this.$route;
 			if (route?.name === 'topics-chat' && route.params?.sessionId === topicId) {
-				this.$router.replace('/');
+				this.$router.push({ name: 'topics' });
 			}
 		},
 		resolvePath(to) {

--- a/ui/src/components/TopicItemActions.test.js
+++ b/ui/src/components/TopicItemActions.test.js
@@ -187,42 +187,6 @@ test('successful delete calls deleteTopic, shows notify and emits deleted', asyn
 	expect(wrapper.emitted('deleted')[0]).toEqual(['t1']);
 });
 
-test('deleting current topic navigates to default route', async () => {
-	mockRequest.mockResolvedValue({ ok: true });
-	const mockReplace = vi.fn();
-
-	const wrapper = createWrapper();
-	wrapper.vm.$route = { name: 'topics-chat', params: { sessionId: 't1' } };
-	wrapper.vm.$router = { replace: mockReplace };
-
-	const store = useTopicsStore();
-	store.items = [{ topicId: 't1', agentId: 'main', title: 'X', createdAt: 100, botId: 'bot-1' }];
-
-	wrapper.vm.deleteOpen = true;
-	await wrapper.vm.onConfirmDelete();
-
-	expect(mockReplace).toHaveBeenCalledWith('/');
-	expect(wrapper.emitted('deleted')).toBeTruthy();
-});
-
-test('deleting non-current topic does not navigate', async () => {
-	mockRequest.mockResolvedValue({ ok: true });
-	const mockReplace = vi.fn();
-
-	const wrapper = createWrapper();
-	wrapper.vm.$route = { name: 'topics-chat', params: { sessionId: 'other-topic' } };
-	wrapper.vm.$router = { replace: mockReplace };
-
-	const store = useTopicsStore();
-	store.items = [{ topicId: 't1', agentId: 'main', title: 'X', createdAt: 100, botId: 'bot-1' }];
-
-	wrapper.vm.deleteOpen = true;
-	await wrapper.vm.onConfirmDelete();
-
-	expect(mockReplace).not.toHaveBeenCalled();
-	expect(wrapper.emitted('deleted')).toBeTruthy();
-});
-
 test('failed delete shows error notify', async () => {
 	mockRequest.mockRejectedValue(new Error('fail'));
 

--- a/ui/src/components/TopicItemActions.vue
+++ b/ui/src/components/TopicItemActions.vue
@@ -125,11 +125,6 @@ export default {
 				const store = useTopicsStore();
 				await store.deleteTopic(this.botId, this.topicId);
 				this.deleteOpen = false;
-				// 若当前正在查看被删除的 topic，跳转到默认路由
-				const route = this.$route;
-				if (route?.name === 'topics-chat' && route.params?.sessionId === this.topicId) {
-					this.$router.replace('/');
-				}
 				this.$emit('deleted', this.topicId);
 			} catch (err) {
 				this.notify.error(this.$t('topic.deleteFailed'));

--- a/ui/src/stores/agent-runs.store.js
+++ b/ui/src/stores/agent-runs.store.js
@@ -1,12 +1,10 @@
 /**
  * Agent Run 全局注册表
- * 职责：跟踪所有活跃的 agent run，缓冲流式消息
+ * 职责：跟踪所有活跃的 agent run，管理 per-connection 事件路由，缓冲流式消息
  * 生命周期独立于 ChatPage / chatStore，run 在页面切换后继续接收事件
- *
- * event:agent 事件由 botsStore.__bridgeConn 集中桥接，所有事件统一通过 __dispatch 到达本 store。
- * 本 store 不再自行管理 per-connection 监听器。
  */
 import { defineStore } from 'pinia';
+import { toRaw } from 'vue';
 import { applyAgentEvent } from '../utils/agent-stream.js';
 
 /** post-acceptance 超时（30 分钟） */
@@ -62,7 +60,7 @@ export const useAgentRunsStore = defineStore('agentRuns', {
 		 * @param {string} opts.botId
 		 * @param {string} opts.runKey
 		 * @param {boolean} opts.topicMode
-		 * @param {object} opts.conn - BotConnection 实例（仅保留引用，不注册监听器）
+		 * @param {object} opts.conn - BotConnection 实例
 		 * @param {object[]} opts.streamingMsgs - 初始流式消息（乐观 user + bot 条目）
 		 */
 		register(runId, { botId, runKey, topicMode, conn, streamingMsgs = [] }) {
@@ -84,16 +82,31 @@ export const useAgentRunsStore = defineStore('agentRuns', {
 				settling: false,
 				lastEventAt: 0,
 				streamingMsgs: [...streamingMsgs],
+				// 非响应式内部引用
 				__conn: conn,
 				__timer: null,
 			};
 			this.runKeyIndex[runKey] = runId;
+
+			// 确保 connection 上有事件路由
+			this.__ensureListener(botId, conn);
 
 			// post-acceptance 超时
 			this.runs[runId].__timer = setTimeout(() => {
 				console.debug('[agentRuns] post-acceptance timeout runId=%s', runId);
 				this.settle(runKey);
 			}, POST_ACCEPT_TIMEOUT_MS);
+		},
+
+		/**
+		 * 确保指定 bot 的 connection 上有 event:agent 监听器
+		 * 用于 re-entry 场景（进入已有活跃 run 的会话）
+		 * @param {string} botId
+		 * @param {object} conn
+		 */
+		ensureListenerForBot(botId, conn) {
+			if (!botId || !conn) return;
+			this.__ensureListener(botId, conn);
 		},
 
 		/**
@@ -110,7 +123,7 @@ export const useAgentRunsStore = defineStore('agentRuns', {
 		},
 
 		/**
-		 * 内部：处理 event:agent 事件路由（由 botsStore.__bridgeConn 集中调用）
+		 * 内部：处理 event:agent 事件路由
 		 * @param {object} payload
 		 */
 		__dispatch(payload) {
@@ -207,6 +220,9 @@ export const useAgentRunsStore = defineStore('agentRuns', {
 		 */
 		__serverMessagesIndicateRunDone(run, messages) {
 			if (!messages?.length) return false;
+			// 检查服务端消息数是否多于 run 开始前的消息数
+			// streamingMsgs 初始包含 [user, blank_bot]，若 run 正常，服务端应有比初始更多的消息
+			// 但 streamingMsgs 可能为空（如断连后 run 已被部分清理），此时 fallback 到简单检查
 			// 从后向前找最后一条 assistant 消息
 			for (let i = messages.length - 1; i >= 0; i--) {
 				const msg = messages[i]?.message;
@@ -242,17 +258,64 @@ export const useAgentRunsStore = defineStore('agentRuns', {
 				delete this.runKeyIndex[run.runKey];
 			}
 			delete this.runs[runId];
+
+			// 若该 botId 下无活跃 run，移除监听器
+			this.__removeListenerIfIdle(run.botId);
 		},
 
+		// --- per-connection 事件监听器管理 ---
+
 		/**
-		 * bot 移除时清理该 bot 的所有 runs
+		 * bot 移除时清理该 bot 的所有 runs 和监听器
 		 * @param {string} botId
 		 */
 		removeByBot(botId) {
+			// 强制 settle 该 bot 的所有活跃 runs
 			const runIds = Object.keys(this.runs).filter((id) => this.runs[id].botId === botId);
 			for (const runId of runIds) {
 				this.__cleanupRun(runId);
 			}
+			// 确保监听器也被清理（__cleanupRun 内的 __removeListenerIfIdle 应已处理，此为防御性清理）
+			if (this.__listeners?.[botId]) {
+				const { handler, conn } = this.__listeners[botId];
+				try { conn.off('event:agent', handler); } catch { /* conn 可能已销毁 */ }
+				delete this.__listeners[botId];
+			}
+		},
+
+		/**
+		 * 确保指定 botId 的 connection 上注册了事件路由
+		 * @param {string} botId
+		 * @param {object} conn
+		 */
+		__ensureListener(botId, conn) {
+			if (!this.__listeners) this.__listeners = {};
+			const existing = this.__listeners[botId];
+			if (existing) {
+				if (toRaw(existing.conn) === toRaw(conn)) return; // 同实例，无需重复
+				// conn 实例已替换，先移除旧 listener
+				try { existing.conn.off('event:agent', existing.handler); } catch { /* 旧 conn 可能已销毁 */ }
+			}
+			const handler = (payload) => this.__dispatch(payload);
+			conn.on('event:agent', handler);
+			this.__listeners[botId] = { handler, conn };
+			console.debug('[agentRuns] listener registered botId=%s', botId);
+		},
+
+		/**
+		 * 若指定 botId 下无活跃 run，移除监听器
+		 * @param {string} botId
+		 */
+		__removeListenerIfIdle(botId) {
+			if (!this.__listeners?.[botId]) return;
+			// 检查是否还有该 botId 的活跃 run
+			const hasActive = Object.values(this.runs).some((r) => r.botId === botId && !r.settled);
+			if (hasActive) return;
+
+			const { handler, conn } = this.__listeners[botId];
+			conn.off('event:agent', handler);
+			delete this.__listeners[botId];
+			console.debug('[agentRuns] listener removed botId=%s', botId);
 		},
 	},
 });

--- a/ui/src/stores/agent-runs.store.test.js
+++ b/ui/src/stores/agent-runs.store.test.js
@@ -6,7 +6,11 @@ import { useAgentRunsStore } from './agent-runs.store.js';
 // --- Helper ---
 
 function mockConn() {
-	return { state: 'connected' };
+	return {
+		state: 'connected',
+		on: vi.fn(),
+		off: vi.fn(),
+	};
 }
 
 function registerRun(store, overrides = {}) {
@@ -50,6 +54,23 @@ describe('useAgentRunsStore', () => {
 			expect(store.runKeyIndex['agent:main:main']).toBe('run-1');
 		});
 
+		test('注册时在 connection 上注册 event:agent 监听器', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			registerRun(store, { conn });
+
+			expect(conn.on).toHaveBeenCalledWith('event:agent', expect.any(Function));
+		});
+
+		test('同一 botId 多个 run 只注册一次监听器', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			registerRun(store, { runId: 'run-1', runKey: 'key1', conn });
+			registerRun(store, { runId: 'run-2', runKey: 'key2', conn });
+
+			expect(conn.on).toHaveBeenCalledTimes(1);
+		});
+
 		test('同一 runKey 重复注册时清理旧 run', () => {
 			const store = useAgentRunsStore();
 			registerRun(store, { runId: 'run-1', runKey: 'agent:main:main' });
@@ -58,15 +79,6 @@ describe('useAgentRunsStore', () => {
 			expect(store.runs['run-1']).toBeUndefined();
 			expect(store.runs['run-2']).toBeTruthy();
 			expect(store.runKeyIndex['agent:main:main']).toBe('run-2');
-		});
-
-		test('不再自行注册 event:agent 监听器（由 botsStore 集中桥接）', () => {
-			const store = useAgentRunsStore();
-			const conn = { state: 'connected', on: vi.fn(), off: vi.fn() };
-			registerRun(store, { conn });
-
-			// conn.on 不应被调用（事件由 botsStore.__bridgeConn 统一注册）
-			expect(conn.on).not.toHaveBeenCalled();
 		});
 	});
 
@@ -190,6 +202,28 @@ describe('useAgentRunsStore', () => {
 		test('settle 不存在的 runKey 不报错', () => {
 			const store = useAgentRunsStore();
 			store.settle('nonexistent');
+		});
+
+		test('settle 后移除空闲 connection 的监听器', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			registerRun(store, { conn });
+
+			store.settle('agent:main:main');
+
+			expect(conn.off).toHaveBeenCalledWith('event:agent', expect.any(Function));
+		});
+
+		test('同一 botId 有其他活跃 run 时不移除监听器', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			registerRun(store, { runId: 'run-1', runKey: 'key1', conn });
+			registerRun(store, { runId: 'run-2', runKey: 'key2', conn });
+
+			store.settle('key1');
+
+			// 不应移除监听器（run-2 仍活跃）
+			expect(conn.off).not.toHaveBeenCalled();
 		});
 	});
 
@@ -363,9 +397,10 @@ describe('useAgentRunsStore', () => {
 	describe('removeByBot', () => {
 		test('清理指定 bot 的所有活跃 runs', () => {
 			const store = useAgentRunsStore();
-			registerRun(store, { runId: 'run-1', runKey: 'key1', botId: '1' });
-			registerRun(store, { runId: 'run-2', runKey: 'key2', botId: '1' });
-			registerRun(store, { runId: 'run-3', runKey: 'key3', botId: '2' });
+			const conn = mockConn();
+			registerRun(store, { runId: 'run-1', runKey: 'key1', botId: '1', conn });
+			registerRun(store, { runId: 'run-2', runKey: 'key2', botId: '1', conn });
+			registerRun(store, { runId: 'run-3', runKey: 'key3', botId: '2', conn });
 
 			store.removeByBot('1');
 
@@ -375,9 +410,103 @@ describe('useAgentRunsStore', () => {
 			expect(store.runs['run-3']).toBeTruthy();
 		});
 
+		test('清理指定 bot 的监听器', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			registerRun(store, { botId: '1', conn });
+
+			store.removeByBot('1');
+
+			expect(conn.off).toHaveBeenCalledWith('event:agent', expect.any(Function));
+		});
+
 		test('无活跃 runs 时不报错', () => {
 			const store = useAgentRunsStore();
 			store.removeByBot('nonexistent');
+		});
+	});
+
+	// =====================================================================
+	// ensureListenerForBot
+	// =====================================================================
+
+	describe('ensureListenerForBot', () => {
+		test('botId 或 conn 为 null 时不崩溃', () => {
+			const store = useAgentRunsStore();
+			store.ensureListenerForBot(null, mockConn());
+			store.ensureListenerForBot('1', null);
+			store.ensureListenerForBot(null, null);
+			store.ensureListenerForBot('', mockConn());
+		});
+
+		test('正常调用后 __listeners 中有对应 botId', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			store.ensureListenerForBot('bot-1', conn);
+
+			expect(conn.on).toHaveBeenCalledWith('event:agent', expect.any(Function));
+			expect(store.__listeners['bot-1']).toBeTruthy();
+		});
+
+		test('重复调用同一 conn 不重复注册', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+			store.ensureListenerForBot('bot-1', conn);
+			store.ensureListenerForBot('bot-1', conn);
+
+			expect(conn.on).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	// =====================================================================
+	// conn 实例替换
+	// =====================================================================
+
+	describe('conn 实例替换', () => {
+		test('新 conn 实例应重新注册监听器', () => {
+			const store = useAgentRunsStore();
+			const connOld = mockConn();
+			const connNew = mockConn();
+
+			registerRun(store, { runId: 'run-1', runKey: 'key1', botId: '1', conn: connOld });
+			expect(connOld.on).toHaveBeenCalledTimes(1);
+
+			// 模拟 bot 移除后重新添加（conn 实例被替换）
+			store.removeByBot('1');
+
+			// 用新 conn 注册新 run
+			registerRun(store, { runId: 'run-2', runKey: 'key2', botId: '1', conn: connNew });
+
+			// 新 conn 应注册了监听器
+			expect(connNew.on).toHaveBeenCalledWith('event:agent', expect.any(Function));
+		});
+
+		test('同一 conn 实例不重复注册', () => {
+			const store = useAgentRunsStore();
+			const conn = mockConn();
+
+			registerRun(store, { runId: 'run-1', runKey: 'key1', botId: '1', conn });
+			registerRun(store, { runId: 'run-2', runKey: 'key2', botId: '1', conn });
+
+			// 同实例只注册一次
+			expect(conn.on).toHaveBeenCalledTimes(1);
+		});
+
+		test('未经 removeByBot 时 conn 替换也能正确处理', () => {
+			const store = useAgentRunsStore();
+			const connOld = mockConn();
+			const connNew = mockConn();
+
+			// 注册 run-1 用旧 conn
+			registerRun(store, { runId: 'run-1', runKey: 'key1', botId: '1', conn: connOld });
+
+			// settle run-1（清理 listener）
+			store.settle('key1');
+			expect(connOld.off).toHaveBeenCalled();
+
+			// 注册 run-2 用新 conn
+			registerRun(store, { runId: 'run-2', runKey: 'key2', botId: '1', conn: connNew });
+			expect(connNew.on).toHaveBeenCalledWith('event:agent', expect.any(Function));
 		});
 	});
 });

--- a/ui/src/stores/bots.store.js
+++ b/ui/src/stores/bots.store.js
@@ -165,11 +165,6 @@ export const useBotsStore = defineStore('bots', {
 				window.dispatchEvent(new CustomEvent('auth:session-expired'));
 			});
 
-			// event:agent 集中桥接（阶段三）
-			conn.on('event:agent', (payload) => {
-				useAgentRunsStore().__dispatch(payload);
-			});
-
 			conn.on('state', (s) => {
 				const bot = this.byId[botId];
 				if (!bot) return;
@@ -229,7 +224,6 @@ export const useBotsStore = defineStore('bots', {
 					const gap = Date.now() - conn.disconnectedAt;
 					if (gap >= BRIEF_DISCONNECT_MS) {
 						console.debug('[bots] reconnect gap=%dms ≥ %dms → refresh stores botId=%s', gap, BRIEF_DISCONNECT_MS, id);
-						this.loadBots().catch(() => {}); // WS 就绪后刷新在线状态
 						useAgentsStore().loadAgents(id).catch(() => {});
 						useSessionsStore().loadAllSessions().catch(() => {});
 						useTopicsStore().loadAllTopics().catch(() => {});

--- a/ui/src/stores/bots.store.test.js
+++ b/ui/src/stores/bots.store.test.js
@@ -633,12 +633,11 @@ describe('WebRTC 集成', () => {
 });
 
 describe('重连后批量状态刷新', () => {
-	test('断连时长 >= BRIEF_DISCONNECT_MS 时刷新 bots/agents/sessions/topics', async () => {
+	test('断连时长 >= BRIEF_DISCONNECT_MS 时刷新 agents/sessions/topics', async () => {
 		const store = useBotsStore();
 		const agentsStore = useAgentsStore();
 		const sessionsStore = useSessionsStore();
 		const topicsStore = useTopicsStore();
-		vi.spyOn(store, 'loadBots').mockResolvedValue();
 		vi.spyOn(agentsStore, 'loadAgents').mockResolvedValue();
 		vi.spyOn(sessionsStore, 'loadAllSessions').mockResolvedValue();
 		vi.spyOn(topicsStore, 'loadAllTopics').mockResolvedValue();
@@ -662,7 +661,6 @@ describe('重连后批量状态刷新', () => {
 			expect(agentsStore.loadAgents).toHaveBeenCalledWith('20');
 		});
 
-		store.loadBots.mockClear();
 		agentsStore.loadAgents.mockClear();
 		sessionsStore.loadAllSessions.mockClear();
 		topicsStore.loadAllTopics.mockClear();
@@ -677,7 +675,6 @@ describe('重连后批量状态刷新', () => {
 
 
 		await vi.waitFor(() => {
-			expect(store.loadBots).toHaveBeenCalled();
 			expect(agentsStore.loadAgents).toHaveBeenCalledWith('20');
 			expect(sessionsStore.loadAllSessions).toHaveBeenCalled();
 			expect(topicsStore.loadAllTopics).toHaveBeenCalled();
@@ -783,7 +780,6 @@ describe('__fullInit 失败重试', () => {
 		checkPluginVersion.mockReturnValueOnce(new Promise((_, rej) => { rejectFirst = rej; }));
 		// 第二次 fullInit 正常成功
 		checkPluginVersion.mockResolvedValue({ ok: true, version: '0.6.0', clawVersion: '2026.3.14' });
-		vi.spyOn(store, 'loadBots').mockResolvedValue();
 
 		let stateCallback;
 		const fakeConn = {

--- a/ui/src/stores/chat.store.js
+++ b/ui/src/stores/chat.store.js
@@ -17,20 +17,6 @@ import { useBotsStore } from './bots.store.js';
 const MSG_PAGE_SIZE = 50;
 
 /**
- * 比较两条消息的 content 是否相同（兼容字符串和 block 数组）
- * @param {string|object[]} a
- * @param {string|object[]} b
- * @returns {boolean}
- */
-function __contentEqual(a, b) {
-	if (a === b) return true;
-	if (typeof a === 'string' || typeof b === 'string') return false;
-	// block 数组：序列化比较
-	try { return JSON.stringify(a) === JSON.stringify(b); }
-	catch { return false; }
-}
-
-/**
  * 创建 ChatStore 实例
  * @param {string} storeKey - 如 'session:1:main' 或 'topic:uuid'
  * @param {object} [opts]
@@ -112,23 +98,12 @@ export function createChatStore(storeKey, opts = {}) {
 			runKey() {
 				return this.topicMode ? this.sessionId : this.chatSessionKey;
 			},
-			/** 合并服务端消息 + 活跃 run 的流式消息（去重乐观消息） */
+			/** 合并服务端消息 + 活跃 run 的流式消息 */
 			allMessages() {
 				const runsStore = useAgentRunsStore();
 				const run = runsStore.getActiveRun(this.runKey);
 				if (run && run.streamingMsgs.length) {
-					// 去重：loadOlderMessages 可能拉回服务端已收录的 user 消息，
-					// 而 streamingMsgs 中仍持有同一条的乐观版本，需跳过以防重复
-					const deduped = run.streamingMsgs.filter((sm) => {
-						if (!sm._local || sm.message?.role !== 'user') return true;
-						// 检查 this.messages 中是否已有服务端版本（非 _local、同 role 且内容相同）
-						return !this.messages.some((m) =>
-							!m._local
-							&& m.message?.role === 'user'
-							&& __contentEqual(m.message.content, sm.message.content),
-						);
-					});
-					if (deduped.length) return [...this.messages, ...deduped];
+					return [...this.messages, ...run.streamingMsgs];
 				}
 				return this.messages;
 			},
@@ -238,6 +213,8 @@ export function createChatStore(storeKey, opts = {}) {
 						this.hasMoreMessages = flatMsgs.length >= limit;
 						this.loading = false;
 						this.__messagesLoaded = true;
+						// 确保 event:agent 监听已注册（loadMessages 是所有入口的共同路径）
+						useAgentRunsStore().ensureListenerForBot(this.botId, conn);
 						console.debug('[chat] loadMessages ok count=%d hasMore=%s', this.messages.length, this.hasMoreMessages);
 
 						// 重连后 reconcile：检查并 settle 僵尸 run / 完成 settling 过渡
@@ -296,8 +273,8 @@ export function createChatStore(storeKey, opts = {}) {
 					const flatMsgs = Array.isArray(result?.messages) ? result.messages : [];
 					const wrapped = wrapOcMessages(flatMsgs);
 
-					// 仅保留 streaming 中的 bot 占位；用户乐观消息已被服务端持久化
-					const localMsgs = this.messages.filter((m) => m._local && m._streaming);
+					// 保留本地消息（streaming/乐观消息）
+					const localMsgs = this.messages.filter((m) => m._local);
 					const prevNonLocalCount = this.messages.length - localMsgs.length;
 
 					this.messages = [...wrapped, ...localMsgs];
@@ -356,6 +333,9 @@ export function createChatStore(storeKey, opts = {}) {
 					console.debug('[chat] loadTopicMessages ok count=%d (was %d)', msgs.length, prevCount);
 					this.messages = msgs;
 					this.__messagesLoaded = true;
+					// 确保 event:agent 监听已注册（loadMessages 是所有入口的共同路径）
+					const topicConn = this.__getConnection();
+					if (topicConn) useAgentRunsStore().ensureListenerForBot(this.botId, topicConn);
 
 					// 重连后 reconcile
 					this.__reconcileRunAfterLoad(this.messages);
@@ -400,15 +380,12 @@ export function createChatStore(storeKey, opts = {}) {
 
 				// 构建乐观消息条目（后续移入 agentRunsStore）
 				const imgFiles = files?.filter((f) => f.isImg && f.file) ?? [];
-				/** @type {Map<File, string>} 缓存 base64，避免同一文件重复编码 */
-				const base64Cache = new Map();
 				let content = text;
 				if (imgFiles.length) {
 					const blocks = [];
 					if (text) blocks.push({ type: 'text', text });
 					for (const f of imgFiles) {
 						const base64 = await fileToBase64(f.file);
-						base64Cache.set(f.file, base64);
 						blocks.push({ type: 'image', data: base64, mimeType: f.file.type || 'image/png' });
 					}
 					content = blocks;
@@ -431,11 +408,11 @@ export function createChatStore(storeKey, opts = {}) {
 				this.messages = [...this.messages, optimisticUser, optimisticBot];
 
 				try {
-					// 构建附件（复用已缓存的 base64）
+					// 构建附件
 					const attachments = [];
 					for (const f of files) {
 						if (!f.file) continue;
-						const base64 = base64Cache.get(f.file) ?? await fileToBase64(f.file);
+						const base64 = await fileToBase64(f.file);
 						attachments.push({
 							type: f.isImg ? 'image' : f.isVoice ? 'audio' : 'file',
 							mimeType: f.file.type || 'application/octet-stream',
@@ -465,7 +442,7 @@ export function createChatStore(storeKey, opts = {}) {
 					const timeoutPromise = new Promise((_, reject) => { timeoutReject = reject; });
 					const cancelPromise = new Promise((_, reject) => { this.__cancelReject = reject; });
 
-					// pre-acceptance 超时（用户可主动取消）
+					// pre-acceptance 30s 超时
 					this.__streamingTimer = setTimeout(() => {
 						if (!this.__accepted) {
 							this.__agentSettled = true;
@@ -475,7 +452,7 @@ export function createChatStore(storeKey, opts = {}) {
 							err.code = 'PRE_ACCEPTANCE_TIMEOUT';
 							timeoutReject(err);
 						}
-					}, 180_000);
+					}, 30_000);
 
 					const runsStore = useAgentRunsStore();
 					const runKey = this.runKey;
@@ -864,11 +841,6 @@ export function createChatStore(storeKey, opts = {}) {
 			 */
 			async loadNextHistorySession() {
 				if (this.topicMode || this.historyExhausted || this.historyLoading) return false;
-
-				// historySessionIds 尚未初始化时不能判定 exhausted
-				if (this.historySessionIds.length === 0 && !this.__messagesLoaded) {
-					return false;
-				}
 
 				// 跳过已在 segments 中的 session
 				while (this.__historyLoadedCount < this.historySessionIds.length) {

--- a/ui/src/stores/chat.store.test.js
+++ b/ui/src/stores/chat.store.test.js
@@ -548,7 +548,7 @@ describe('useChatStore', () => {
 			expect(agentCall[1].sessionKey).toBeUndefined();
 		});
 
-		test('带图片文件时内容变为 blocks 数组，且 fileToBase64 只调用一次（缓存复用）', async () => {
+		test('带图片文件时内容变为 blocks 数组', async () => {
 			const { fileToBase64 } = await import('../utils/file-helper.js');
 			fileToBase64.mockResolvedValue('imgbase64');
 
@@ -579,8 +579,6 @@ describe('useChatStore', () => {
 			const agentCall = conn.request.mock.calls.find((c) => c[0] === 'agent');
 			expect(agentCall[1].attachments).toHaveLength(1);
 			expect(agentCall[1].attachments[0].type).toBe('image');
-			// 同一图片文件只编码一次（乐观消息缓存复用到 attachments）
-			expect(fileToBase64).toHaveBeenCalledTimes(1);
 		});
 
 		test('发送失败（request 抛出）时清理 streaming 状态并重新抛出', async () => {
@@ -604,12 +602,13 @@ describe('useChatStore', () => {
 			expect(store.messages.some((m) => m._local)).toBe(false);
 		});
 
-		test('pre-acceptance 180s 超时：sending 置 false，__agentSettled 为 true，抛出 PRE_ACCEPTANCE_TIMEOUT', async () => {
+		test('pre-acceptance 30s 超时：sending 置 false，__agentSettled 为 true，抛出 PRE_ACCEPTANCE_TIMEOUT', async () => {
 			vi.useFakeTimers();
 			const botsStore = useBotsStore();
 			botsStore.setBots([{ id: '1', online: true }]);
 
 			const conn = mockConn();
+			// 永不 resolve，也不调用 onAccepted
 			conn.request.mockImplementation((method) => {
 				if (method === 'agent') return new Promise(() => {});
 				return Promise.resolve(null);
@@ -621,15 +620,9 @@ describe('useChatStore', () => {
 			store.botId = '1';
 			store.chatSessionKey = 'agent:main:main';
 
-			// 179s 时不应超时
-			const sendPromise = store.sendMessage('hello');
-			await vi.advanceTimersByTimeAsync(179_000);
-			expect(store.sending).toBe(true);
-
-			// 180s 时应超时
 			const [, result] = await Promise.allSettled([
-				vi.advanceTimersByTimeAsync(1_000),
-				sendPromise,
+				vi.advanceTimersByTimeAsync(30_000),
+				store.sendMessage('hello'),
 			]);
 
 			expect(result.status).toBe('rejected');
@@ -877,8 +870,38 @@ describe('useChatStore', () => {
 			expect(store.messages.some((m) => m._local)).toBe(false);
 		});
 
-		// event:agent 监听器已由 botsStore.__bridgeConn 集中管理
-		// register 不再自行注册/注销 conn.on('event:agent')，相关测试已移至 agent-runs.store.test.js
+		test('conn.on 和 conn.off 以相同函数引用调用 "event:agent"', async () => {
+			const botsStore = useBotsStore();
+			botsStore.setBots([{ id: '1', online: true }]);
+
+			const conn = mockConn();
+			conn.request.mockImplementation((method, params, options) => {
+				if (method === 'agent') {
+					options?.onAccepted?.({ runId: 'run-ref' });
+					return Promise.resolve({ status: 'ok' });
+				}
+				if (method === 'sessions.get') return Promise.resolve({ messages: [] });
+				if (method === 'chat.history') return Promise.resolve({ sessionId: 'cur' });
+				return Promise.resolve(null);
+			});
+			mockConnections.set('1', conn);
+
+			const store = useChatStore();
+			store.sessionId = 'sess-1';
+			store.botId = '1';
+			store.chatSessionKey = 'agent:main:main';
+
+			await store.sendMessage('hello');
+
+			const onCalls = conn.on.mock.calls.filter((c) => c[0] === 'event:agent');
+			const offCalls = conn.off.mock.calls.filter((c) => c[0] === 'event:agent');
+			// register 注册一次 listener，settle 后 removeListenerIfIdle 移除，
+			// reconcile 期间 loadMessages 内 ensureListenerForBot 重新注册
+			expect(onCalls.length).toBeGreaterThanOrEqual(1);
+			expect(offCalls.length).toBeGreaterThanOrEqual(1);
+			// 验证首次 register/settle 的函数引用匹配
+			expect(onCalls[0][1]).toBe(offCalls[0][1]);
+		});
 	});
 
 	// =====================================================================
@@ -1165,101 +1188,6 @@ describe('useChatStore', () => {
 
 			expect(store.isMainSession).toBe(false);
 		});
-
-		// --- allMessages 去重 ---
-
-		test('allMessages 合并 streamingMsgs 时跳过已在 messages 中的乐观 user 消息', () => {
-			const store = useChatStore();
-			store.chatSessionKey = 'agent:main:main';
-
-			// 模拟 loadOlderMessages 拉回的服务端消息（含用户发送的消息）
-			store.messages = [
-				{ type: 'message', id: 'oc-0', message: { role: 'assistant', content: 'hi' } },
-				{ type: 'message', id: 'oc-1', message: { role: 'user', content: '你好' } },
-			];
-
-			// 模拟 agentRunsStore 中仍有乐观 user 消息 + 流式 bot 消息
-			const runsStore = useAgentRunsStore();
-			const runId = 'run-1';
-			const runKey = store.runKey;
-			runsStore.runs[runId] = {
-				runId,
-				runKey,
-				settled: false,
-				settling: false,
-				streamingMsgs: [
-					{ type: 'message', id: '__local_user_123', _local: true, message: { role: 'user', content: '你好' } },
-					{ type: 'message', id: '__local_bot_123', _local: true, _streaming: true, message: { role: 'assistant', content: '回复中…' } },
-				],
-			};
-			runsStore.runKeyIndex[runKey] = runId;
-
-			const all = store.allMessages;
-			// 乐观 user 消息应被去重，只保留服务端版本 + 流式 bot 消息
-			const userMsgs = all.filter((m) => m.message.role === 'user');
-			expect(userMsgs).toHaveLength(1);
-			expect(userMsgs[0].id).toBe('oc-1');
-			// 流式 bot 消息保留
-			expect(all.some((m) => m.id === '__local_bot_123')).toBe(true);
-		});
-
-		test('allMessages 无重复时保留全部 streamingMsgs', () => {
-			const store = useChatStore();
-			store.chatSessionKey = 'agent:main:main';
-
-			store.messages = [
-				{ type: 'message', id: 'oc-0', message: { role: 'assistant', content: 'hi' } },
-			];
-
-			const runsStore = useAgentRunsStore();
-			const runId = 'run-2';
-			const runKey = store.runKey;
-			runsStore.runs[runId] = {
-				runId,
-				runKey,
-				settled: false,
-				settling: false,
-				streamingMsgs: [
-					{ type: 'message', id: '__local_user_456', _local: true, message: { role: 'user', content: '新消息' } },
-					{ type: 'message', id: '__local_bot_456', _local: true, _streaming: true, message: { role: 'assistant', content: '' } },
-				],
-			};
-			runsStore.runKeyIndex[runKey] = runId;
-
-			const all = store.allMessages;
-			expect(all).toHaveLength(3);
-		});
-
-		test('allMessages 对 block 数组内容也能正确去重', () => {
-			const store = useChatStore();
-			store.chatSessionKey = 'agent:main:main';
-
-			const blockContent = [{ type: 'text', text: '带图消息' }, { type: 'image', data: 'abc' }];
-			store.messages = [
-				{ type: 'message', id: 'oc-0', message: { role: 'user', content: blockContent } },
-			];
-
-			const runsStore = useAgentRunsStore();
-			const runId = 'run-3';
-			const runKey = store.runKey;
-			// streamingMsgs 中有相同内容的乐观版本（不同引用但相同结构）
-			runsStore.runs[runId] = {
-				runId,
-				runKey,
-				settled: false,
-				settling: false,
-				streamingMsgs: [
-					{ type: 'message', id: '__local_user_789', _local: true, message: { role: 'user', content: [{ type: 'text', text: '带图消息' }, { type: 'image', data: 'abc' }] } },
-					{ type: 'message', id: '__local_bot_789', _local: true, _streaming: true, message: { role: 'assistant', content: '' } },
-				],
-			};
-			runsStore.runKeyIndex[runKey] = runId;
-
-			const all = store.allMessages;
-			const userMsgs = all.filter((m) => m.message.role === 'user');
-			expect(userMsgs).toHaveLength(1);
-			expect(userMsgs[0].id).toBe('oc-0');
-		});
 	});
 
 	// =====================================================================
@@ -1510,10 +1438,9 @@ describe('useChatStore', () => {
 			expect(ok).toBe(false);
 		});
 
-		test('无更多 session 时设置 historyExhausted（消息已加载）', async () => {
+		test('无更多 session 时设置 historyExhausted', async () => {
 			const store = useChatStore();
 			store.historySessionIds = [];
-			store.__messagesLoaded = true;
 
 			const ok = await store.loadNextHistorySession();
 			expect(ok).toBe(false);
@@ -1593,31 +1520,6 @@ describe('useChatStore', () => {
 			const ok = await store.loadNextHistorySession();
 			expect(ok).toBe(false);
 			expect(store.__historyLoadedCount).toBe(1);
-			expect(store.historyExhausted).toBe(true);
-		});
-
-		test('消息未加载完成时空 historySessionIds 不设 exhausted', async () => {
-			const store = useChatStore();
-			store.botId = '1';
-			store.chatSessionKey = 'agent:main:main';
-			// __messagesLoaded 默认 false，historySessionIds 默认 []
-			expect(store.__messagesLoaded).toBe(false);
-			expect(store.historySessionIds).toEqual([]);
-
-			const ok = await store.loadNextHistorySession();
-			expect(ok).toBe(false);
-			expect(store.historyExhausted).toBe(false); // 不应被置 true
-		});
-
-		test('消息已加载后空 historySessionIds 正常设 exhausted', async () => {
-			const store = useChatStore();
-			store.botId = '1';
-			store.chatSessionKey = 'agent:main:main';
-			store.__messagesLoaded = true;
-			store.historySessionIds = [];
-
-			const ok = await store.loadNextHistorySession();
-			expect(ok).toBe(false);
 			expect(store.historyExhausted).toBe(true);
 		});
 	});
@@ -2135,35 +2037,6 @@ describe('useChatStore', () => {
 			expect(localMsg.id).toBe('__local_bot_1');
 		});
 
-		test('loadOlderMessages: 用户乐观消息（_local && !_streaming）不重复', async () => {
-			const conn = mockConn();
-			const initialMsgs = Array.from({ length: 50 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
-			setupConnForLoad(conn, { flatMessages: initialMsgs });
-			mockConnections.set('1', conn);
-
-			const store = createChatStore('session:1:main', { botId: '1', agentId: 'main' });
-			await store.activate();
-
-			// 模拟用户发送后的乐观消息（_local=true, _streaming 未设置）
-			store.messages = [
-				...store.messages,
-				{ type: 'message', id: '__local_user_1', _local: true, message: { role: 'user', content: 'hello' } },
-			];
-
-			// 服务端返回更多消息，其中已包含用户消息
-			const olderMsgs = Array.from({ length: 80 }, (_, i) => ({ role: 'user', content: `msg-${i}` }));
-			conn.request.mockImplementation((method) => {
-				if (method === 'sessions.get') return Promise.resolve({ messages: olderMsgs });
-				return Promise.resolve(null);
-			});
-
-			await store.loadOlderMessages();
-			// 用户乐观消息不应被保留，只有服务端返回的 80 条
-			expect(store.messages).toHaveLength(80);
-			const localMsg = store.messages.find((m) => m._local);
-			expect(localMsg).toBeFalsy();
-		});
-
 		test('loadOlderMessages: topic 模式下不触发', async () => {
 			const conn = mockConn();
 			conn.request.mockImplementation((method) => {
@@ -2387,6 +2260,92 @@ describe('useChatStore', () => {
 			await store.loadMessages({ silent: true });
 
 			expect(runsStore.isRunning(store.runKey)).toBe(false);
+		});
+
+		test('loadMessages 成功后调用 ensureListenerForBot（session 模式）', async () => {
+			const conn = mockConn();
+			setupConnForLoad(conn, {
+				flatMessages: [{ role: 'user', content: 'hi' }],
+			});
+			mockConnections.set('1', conn);
+
+			const store = createChatStore('session:1:main', { botId: '1', agentId: 'main' });
+			const runsStore = useAgentRunsStore();
+			const spy = vi.spyOn(runsStore, 'ensureListenerForBot');
+
+			await store.activate();
+
+			expect(spy).toHaveBeenCalledWith('1', conn);
+			spy.mockRestore();
+		});
+
+		test('connReady 延迟路径：连接就绪后 loadMessages 触发 ensureListenerForBot', async () => {
+			// activate 时连接未就绪
+			const conn = mockConn({ state: 'connecting' });
+			mockConnections.set('1', conn);
+
+			const store = createChatStore('session:1:main', { botId: '1', agentId: 'main' });
+			await store.activate();
+
+			expect(store.loading).toBe(true);
+			expect(store.__messagesLoaded).toBe(false);
+
+			const runsStore = useAgentRunsStore();
+			const spy = vi.spyOn(runsStore, 'ensureListenerForBot');
+
+			// 模拟 connReady：连接就绪后外部调用 loadMessages
+			conn.state = 'connected';
+			setupConnForLoad(conn, {
+				flatMessages: [{ role: 'user', content: 'hello' }],
+			});
+			await store.loadMessages();
+
+			expect(store.__messagesLoaded).toBe(true);
+			expect(spy).toHaveBeenCalledWith('1', conn);
+			spy.mockRestore();
+		});
+
+		test('re-entry 路径：静默刷新时 ensureListenerForBot 也被调用', async () => {
+			const conn = mockConn();
+			setupConnForLoad(conn, {
+				flatMessages: [{ role: 'user', content: 'hi' }],
+			});
+			mockConnections.set('1', conn);
+
+			const store = createChatStore('session:1:main', { botId: '1', agentId: 'main' });
+			await store.activate();
+
+			const runsStore = useAgentRunsStore();
+			const spy = vi.spyOn(runsStore, 'ensureListenerForBot');
+
+			// 模拟 re-entry：activate 再次调用触发 silent loadMessages
+			await store.activate();
+			// 等待 silent loadMessages 完成
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(spy).toHaveBeenCalledWith('1', conn);
+			spy.mockRestore();
+		});
+
+		test('topic 模式下 loadMessages 成功后也调用 ensureListenerForBot', async () => {
+			const conn = mockConn();
+			conn.request.mockImplementation((method) => {
+				if (method === 'coclaw.sessions.getById') {
+					return Promise.resolve({ messages: [{ role: 'user', content: 'topic msg' }] });
+				}
+				return Promise.resolve(null);
+			});
+			mockConnections.set('1', conn);
+
+			const store = createChatStore('topic:uuid-123', { botId: '1', agentId: 'main' });
+			const runsStore = useAgentRunsStore();
+			const spy = vi.spyOn(runsStore, 'ensureListenerForBot');
+
+			await store.activate();
+
+			expect(store.__messagesLoaded).toBe(true);
+			expect(spy).toHaveBeenCalledWith('1', conn);
+			spy.mockRestore();
 		});
 	});
 });

--- a/ui/src/utils/session-msg-group.js
+++ b/ui/src/utils/session-msg-group.js
@@ -105,7 +105,7 @@ function createBotTask(id) {
 function processAssistant(task, msg) {
 	const content = msg.content;
 	const blocks = normalizeBlocks(content);
-	const isFinal = !!msg.stopReason && msg.stopReason !== 'toolUse';
+	const isFinal = msg.stopReason === 'stop' || msg.stopReason === 'end_turn';
 
 	for (const block of blocks) {
 		if (block.type === 'thinking' && block.thinking) {

--- a/ui/src/utils/session-msg-group.test.js
+++ b/ui/src/utils/session-msg-group.test.js
@@ -436,48 +436,6 @@ describe('groupSessionMessages', () => {
 		expect(result[0].images[0].data).toBe('valid');
 	});
 
-	test('stopReason=max_tokens 的 assistant 文本归入 resultText', () => {
-		const entries = [
-			userEntry('u1', '写一篇文章'),
-			assistantEntry('a1', { text: '这是文章内容...', stopReason: 'max_tokens' }),
-		];
-		const result = groupSessionMessages(entries);
-		expect(result[1].resultText).toBe('这是文章内容...');
-	});
-
-	test('stopReason=stop_sequence 的 assistant 文本归入 resultText', () => {
-		const entries = [
-			userEntry('u1', '问题'),
-			assistantEntry('a1', { text: '回答内容', stopReason: 'stop_sequence' }),
-		];
-		const result = groupSessionMessages(entries);
-		expect(result[1].resultText).toBe('回答内容');
-	});
-
-	test('stopReason=end 的 assistant 文本归入 resultText', () => {
-		const entries = [
-			userEntry('u1', '问题'),
-			assistantEntry('a1', { text: '回答', stopReason: 'end' }),
-		];
-		const result = groupSessionMessages(entries);
-		expect(result[1].resultText).toBe('回答');
-	});
-
-	test('tool call 后以 max_tokens 结束，resultText 正确填充', () => {
-		const entries = [
-			userEntry('u1', '帮我处理'),
-			assistantEntry('a1', {
-				toolCalls: [{ name: 'process' }],
-				stopReason: 'toolUse',
-			}),
-			toolResultEntry('tr1', '处理结果'),
-			assistantEntry('a2', { text: '最终输出被截断...', stopReason: 'max_tokens' }),
-		];
-		const result = groupSessionMessages(entries);
-		expect(result[1].resultText).toBe('最终输出被截断...');
-		expect(result[1].steps).toContainEqual({ kind: 'toolCall', name: 'process' });
-	});
-
 	test('tool_use block type 也被识别', () => {
 		const entries = [
 			userEntry('u1', '问题'),

--- a/ui/src/views/ChatPage.test.js
+++ b/ui/src/views/ChatPage.test.js
@@ -87,12 +87,6 @@ const i18nMap = {
 	'chat.sessionNotFound': 'Session no longer exists',
 	'topic.newTopic': 'New topic',
 	'topic.createFailed': 'Failed to create topic',
-	'chat.errRpcTimeout': 'Message timed out',
-	'chat.errPreAcceptTimeout': 'Agent response timed out',
-	'chat.errWsClosed': 'Connection lost',
-	'chat.errWsSendFailed': 'Send failed (ws)',
-	'chat.errRtcSendFailed': 'Send failed (rtc)',
-	'chat.errUnknown': 'Something went wrong',
 };
 
 const mockRouter = { push: vi.fn(), replace: vi.fn() };
@@ -323,7 +317,7 @@ describe('ChatPage send message', () => {
 		expect(mockRestoreFiles).toHaveBeenCalledWith(files);
 	});
 
-	test('发送异常时恢复输入框和文件并显示友好 notify（未知错误）', async () => {
+	test('发送异常时恢复输入框和文件并显示 notify', async () => {
 		const wrapper = createWrapper();
 		setupAgents();
 		const chatStore = getChatStore();
@@ -338,8 +332,7 @@ describe('ChatPage send message', () => {
 		await flushPromises();
 
 		expect(wrapper.vm.inputText).toBe('hello');
-		// 未知错误码 → 通用友好文案
-		expect(mockNotify.error).toHaveBeenCalledWith('Something went wrong');
+		expect(mockNotify.error).toHaveBeenCalledWith('fail');
 		expect(mockRestoreFiles).toHaveBeenCalledWith(files);
 	});
 
@@ -374,99 +367,6 @@ describe('ChatPage send message', () => {
 		await flushPromises();
 
 		expect(sendSpy).not.toHaveBeenCalled();
-	});
-
-	test('RPC_TIMEOUT 错误显示友好文案并回填输入框', async () => {
-		const wrapper = createWrapper();
-		setupAgents();
-		const chatStore = getChatStore();
-		chatStore.__accepted = false;
-		const err = new Error('rpc timeout');
-		err.code = 'RPC_TIMEOUT';
-		vi.spyOn(chatStore, 'sendMessage').mockRejectedValue(err);
-		await flushPromises();
-
-		wrapper.vm.inputText = 'my message';
-		const input = wrapper.findComponent({ name: 'ChatInput' });
-		input.vm.$emit('send', { text: 'my message', files: [] });
-		await flushPromises();
-
-		expect(mockNotify.error).toHaveBeenCalledWith('Message timed out');
-		expect(wrapper.vm.inputText).toBe('my message');
-	});
-
-	test('PRE_ACCEPTANCE_TIMEOUT 错误显示友好文案并回填输入框', async () => {
-		const wrapper = createWrapper();
-		setupAgents();
-		const chatStore = getChatStore();
-		chatStore.__accepted = false;
-		const err = new Error('pre-acceptance timeout');
-		err.code = 'PRE_ACCEPTANCE_TIMEOUT';
-		vi.spyOn(chatStore, 'sendMessage').mockRejectedValue(err);
-		await flushPromises();
-
-		wrapper.vm.inputText = 'my message';
-		const input = wrapper.findComponent({ name: 'ChatInput' });
-		input.vm.$emit('send', { text: 'my message', files: [] });
-		await flushPromises();
-
-		expect(mockNotify.error).toHaveBeenCalledWith('Agent response timed out');
-		expect(wrapper.vm.inputText).toBe('my message');
-	});
-
-	test('WS_CLOSED 错误显示友好文案并回填输入框', async () => {
-		const wrapper = createWrapper();
-		setupAgents();
-		const chatStore = getChatStore();
-		chatStore.__accepted = false;
-		const err = new Error('not connected');
-		err.code = 'WS_CLOSED';
-		vi.spyOn(chatStore, 'sendMessage').mockRejectedValue(err);
-		await flushPromises();
-
-		wrapper.vm.inputText = 'my message';
-		const input = wrapper.findComponent({ name: 'ChatInput' });
-		input.vm.$emit('send', { text: 'my message', files: [] });
-		await flushPromises();
-
-		expect(mockNotify.error).toHaveBeenCalledWith('Connection lost');
-		expect(wrapper.vm.inputText).toBe('my message');
-	});
-
-	test('WS_SEND_FAILED 错误显示友好文案', async () => {
-		const wrapper = createWrapper();
-		setupAgents();
-		const chatStore = getChatStore();
-		chatStore.__accepted = false;
-		const err = new Error('ws send failed');
-		err.code = 'WS_SEND_FAILED';
-		vi.spyOn(chatStore, 'sendMessage').mockRejectedValue(err);
-		await flushPromises();
-
-		wrapper.vm.inputText = 'my message';
-		const input = wrapper.findComponent({ name: 'ChatInput' });
-		input.vm.$emit('send', { text: 'my message', files: [] });
-		await flushPromises();
-
-		expect(mockNotify.error).toHaveBeenCalledWith('Send failed (ws)');
-	});
-
-	test('RTC_SEND_FAILED 错误显示友好文案', async () => {
-		const wrapper = createWrapper();
-		setupAgents();
-		const chatStore = getChatStore();
-		chatStore.__accepted = false;
-		const err = new Error('rtc send failed');
-		err.code = 'RTC_SEND_FAILED';
-		vi.spyOn(chatStore, 'sendMessage').mockRejectedValue(err);
-		await flushPromises();
-
-		wrapper.vm.inputText = 'my message';
-		const input = wrapper.findComponent({ name: 'ChatInput' });
-		input.vm.$emit('send', { text: 'my message', files: [] });
-		await flushPromises();
-
-		expect(mockNotify.error).toHaveBeenCalledWith('Send failed (rtc)');
 	});
 
 	test('sending 中不重复发送', async () => {
@@ -610,43 +510,6 @@ describe('ChatPage watchers', () => {
 		botsStore.byId['bot-1'].connState = 'connected';
 		await wrapper.vm.$nextTick();
 
-		expect(loadSpy).toHaveBeenCalled();
-	});
-
-	test('connReady immediate: 挂载时 bot 已连接则立即加载消息', async () => {
-		// 预创建 pinia 并填充 bot 状态，模拟"返回列表后再进入会话"
-		const pinia = createPinia();
-		setActivePinia(pinia);
-
-		const botsStore = useBotsStore();
-		botsStore.setBots([{ id: 'bot-1', name: 'Bot', online: true }]);
-		botsStore.byId['bot-1'].connState = 'connected';
-		setupAgents();
-
-		// 预创建 chatStore 并挂 spy（组件 computed 会复用同一实例）
-		const chatStore = chatStoreManager.get('session:bot-1:main', { botId: 'bot-1', agentId: 'main' });
-		chatStore.__initialized = true; // 模拟已初始化过（非首次进入）
-		chatStore.__messagesLoaded = true;
-		const loadSpy = vi.spyOn(chatStore, 'loadMessages').mockResolvedValue(true);
-
-		mount(ChatPage, {
-			global: {
-				plugins: [pinia],
-				mocks: {
-					$t: (key) => i18nMap[key] ?? key,
-					$route: {
-						name: 'chat',
-						params: { botId: 'bot-1', agentId: 'main' },
-						path: '/chat/bot-1/main',
-						query: {},
-					},
-					$router: mockRouter,
-				},
-			},
-		});
-		await flushPromises();
-
-		// connReady 在挂载时即为 true，immediate watcher 应触发 loadMessages
 		expect(loadSpy).toHaveBeenCalled();
 	});
 
@@ -812,63 +675,5 @@ describe('ChatPage scroll', () => {
 			wrapper.vm.onScroll();
 			expect(wrapper.vm.userScrolledUp).toBe(true);
 		}
-	});
-
-	test('scrollToBottom $nextTick 内二次检查 userScrolledUp（竞态防护）', async () => {
-		const wrapper = createWrapper();
-		await flushPromises();
-
-		const scrollContainer = wrapper.vm.$refs.scrollContainer;
-		if (!scrollContainer) return;
-
-		const scrollToSpy = vi.fn();
-		scrollContainer.scrollTo = scrollToSpy;
-		Object.defineProperties(scrollContainer, {
-			scrollHeight: { value: 1000, configurable: true },
-			scrollTop: { value: 940, configurable: true, writable: true },
-			clientHeight: { value: 500, configurable: true },
-		});
-
-		// 初始状态：用户在底部
-		wrapper.vm.userScrolledUp = false;
-
-		// 调用 scrollToBottom，同步检查通过，$nextTick 入队
-		wrapper.vm.scrollToBottom();
-
-		// 模拟竞态：$nextTick 排队期间用户上划
-		wrapper.vm.userScrolledUp = true;
-
-		// 等待 $nextTick 和 rAF 执行
-		await wrapper.vm.$nextTick();
-		await new Promise(r => requestAnimationFrame(r));
-
-		// 二次检查应阻止 scrollTo 调用
-		expect(scrollToSpy).not.toHaveBeenCalled();
-	});
-
-	test('scrollToBottom force=true 即使 userScrolledUp 也执行滚动', async () => {
-		const wrapper = createWrapper();
-		await flushPromises();
-
-		const scrollContainer = wrapper.vm.$refs.scrollContainer;
-		if (!scrollContainer) return;
-
-		const scrollToSpy = vi.fn();
-		scrollContainer.scrollTo = scrollToSpy;
-		Object.defineProperties(scrollContainer, {
-			scrollHeight: { value: 1000, configurable: true },
-			scrollTop: { value: 940, configurable: true, writable: true },
-			clientHeight: { value: 500, configurable: true },
-		});
-
-		wrapper.vm.userScrolledUp = true;
-
-		wrapper.vm.scrollToBottom(true);
-
-		await wrapper.vm.$nextTick();
-		await new Promise(r => requestAnimationFrame(r));
-
-		// force=true 时应忽略 userScrolledUp，执行 scrollTo
-		expect(scrollToSpy).toHaveBeenCalled();
 	});
 });

--- a/ui/src/views/ChatPage.vue
+++ b/ui/src/views/ChatPage.vue
@@ -37,7 +37,7 @@
 
 		<!-- flex-1 + min-h-0：让 main 填充剩余空间并内部滚动；移除 min-h-0 会导致撑开父容器 -->
 		<main ref="scrollContainer" class="flex-1 min-h-0 overflow-x-hidden overflow-y-auto" @scroll="onScroll" @wheel="onWheel">
-			<div class="mx-auto w-full max-w-3xl" :style="!__scrollReady && chatMessages.length ? { visibility: 'hidden' } : undefined">
+			<div class="mx-auto w-full max-w-3xl">
 				<div v-if="isBotOffline" class="mx-4 mt-4 rounded-lg bg-warning/10 px-4 py-2 text-center text-sm text-warning">
 					{{ $t('chat.botOffline') }}
 				</div>
@@ -93,7 +93,7 @@
 			ref="chatInput"
 			v-model="inputText"
 			:sending="chatStore?.isSending ?? false"
-			:disabled="inputLocked || (isNewTopic ? (!newTopicReady || __creatingTopic) : (isTopicRoute ? (!currentSessionId || isBotOffline || isLoadingChat) : (!routeBotId || isBotOffline || isLoadingChat)))"
+			:disabled="isNewTopic ? (!newTopicReady || __creatingTopic) : (isTopicRoute ? (!currentSessionId || isBotOffline || isLoadingChat) : (!routeBotId || isBotOffline || isLoadingChat))"
 			@send="onSendMessage"
 			@cancel="onCancelSend"
 		>
@@ -125,6 +125,7 @@ import { isCapacitorApp } from '../utils/platform.js';
 import { usePullRefreshSuppress } from '../composables/use-pull-refresh.js';
 import { isMobileViewport } from '../utils/layout.js';
 import { useDraftStore } from '../stores/draft.store.js';
+import { useAgentRunsStore } from '../stores/agent-runs.store.js';
 
 export default {
 	name: 'ChatPage',
@@ -158,8 +159,6 @@ export default {
 			__creatingTopic: false,
 			// 历史加载进行中，阻止 scrollToBottom 干扰位置恢复
 			__loadingHistory: false,
-			// 首次消息加载 + scrollToBottom 完成前隐藏消息列表，防止闪顶
-			__scrollReady: false,
 		};
 	},
 	computed: {
@@ -176,10 +175,6 @@ export default {
 		inputText: {
 			get() { return this.draftKey ? this.draftStore.getDraft(this.draftKey) : ''; },
 			set(val) { if (this.draftKey) this.draftStore.setDraft(this.draftKey, val); },
-		},
-		/** 发送已开始但尚未 accepted 期间锁定输入 */
-		inputLocked() {
-			return !!(this.chatStore?.sending && !this.chatStore?.__accepted);
 		},
 		chatRootClasses() {
 			return isCapacitorApp ? 'flex-1 min-h-0' : 'h-dvh-safe';
@@ -371,7 +366,6 @@ export default {
 				if (this.__creatingTopic) return;
 				if (store && store !== prevStore) {
 					this.showNoMoreHint = false;
-					this.__scrollReady = false;
 					store.activate();
 				}
 			},
@@ -387,34 +381,31 @@ export default {
 			}
 			// 上线后由 connReady watcher 驱动消息加载
 		},
-		/** connReady 驱动消息加载：首次加载或重连刷新
-		 * immediate: 确保组件挂载时 connReady 已为 true 的场景也能触发加载
-		 * （如返回列表后重新进入会话，bot 已连接但 watcher 不会为初始值触发）
-		 */
-		connReady: {
-			immediate: true,
-			async handler(ready) {
-				if (!ready || !this.chatStore) return;
-				// 与 __handleForegroundResume 去重
-				this.__lastResumeAt = Date.now();
-				// WS 重连时清理挂起的 slash command（event:chat 可能在断连期间丢失）
-				this.chatStore.__reconcileSlashCommand();
-				const isFirstLoad = !this.chatStore.__messagesLoaded;
-				if (isFirstLoad) {
-					await this.chatStore.loadMessages();
-					if (this.__unmounted || !this.chatStore) return;
-					if (!this.chatStore.topicMode) this.chatStore.__loadChatHistory();
-				} else {
-					this.chatStore.loadMessages({ silent: true });
-				}
-				// 首次加载完成后：强制滚到底部，并检测内容是否不足以填满容器
-				if (isFirstLoad) {
-					this.$nextTick(() => {
-						this.scrollToBottom(true);
-						this.__autoFillHistory();
-					});
-				}
-			},
+		/** connReady 驱动消息加载：首次加载或重连刷新 */
+		async connReady(ready) {
+			if (!ready || !this.chatStore) return;
+			// 与 __handleForegroundResume 去重
+			this.__lastResumeAt = Date.now();
+			// WS 重连时清理挂起的 slash command（event:chat 可能在断连期间丢失）
+			this.chatStore.__reconcileSlashCommand();
+			const isFirstLoad = !this.chatStore.__messagesLoaded;
+			if (isFirstLoad) {
+				await this.chatStore.loadMessages();
+				if (this.__unmounted || !this.chatStore) return;
+				// 确保 event:agent 监听（connReady 延迟路径）
+				const conn = this.chatStore.__getConnection?.();
+				if (conn) useAgentRunsStore().ensureListenerForBot(this.currentBotId, conn);
+				if (!this.chatStore.topicMode) this.chatStore.__loadChatHistory();
+			} else {
+				this.chatStore.loadMessages({ silent: true });
+			}
+			// 首次加载完成后：强制滚到底部，并检测内容是否不足以填满容器
+			if (isFirstLoad) {
+				this.$nextTick(() => {
+					this.scrollToBottom(true);
+					this.__autoFillHistory();
+				});
+			}
 		},
 		chatMessages(msgs, oldMsgs) {
 			this.scrollToBottom();
@@ -463,44 +454,38 @@ export default {
 
 			const savedText = this.inputText;
 			const draftKey = this.draftKey;
+			// 清空输入框显示，但在 draftStore 中保留文本（作为 pending draft）
+			// 若发送期间进程被 kill，恢复后 draft 仍可读取
 			this.inputText = '';
+			if (draftKey && savedText) {
+				this.draftStore.setDraft(draftKey, savedText);
+			}
 			this.userScrolledUp = false;
 			this.scrollToBottom();
 
 			try {
 				const result = await this.chatStore.sendMessage(text, files);
 				if (!result.accepted) {
-					// 用闭包 draftKey 恢复，组件可能已 unmount
-					if (draftKey) this.draftStore.setDraft(draftKey, savedText);
+					this.inputText = savedText;
 					this.$refs.chatInput?.restoreFiles(files);
 				}
 				else {
+					// 发送成功，清除 pending draft
+					if (draftKey) this.draftStore.clearDraft(draftKey);
 					this.__tryGenerateTitle();
 				}
 			}
 			catch (err) {
-				// 根据 err.code 映射友好文案
-				const errMsg = this.__sendErrorMessage(err);
-				this.notify.error(errMsg);
+				this.notify.error(err?.message || this.$t('chat.orphanSendFailed'));
 				if (!this.chatStore?.__accepted) {
-					if (draftKey) this.draftStore.setDraft(draftKey, savedText);
+					this.inputText = savedText;
 					this.$refs.chatInput?.restoreFiles(files);
 				}
+				else {
+					// 已 accepted，发送已被服务端接受，清除 draft
+					if (draftKey) this.draftStore.clearDraft(draftKey);
+				}
 			}
-		},
-
-		/** 根据 err.code 返回用户友好的错误消息 */
-		__sendErrorMessage(err) {
-			const codeMap = {
-				RPC_TIMEOUT: 'chat.errRpcTimeout',
-				PRE_ACCEPTANCE_TIMEOUT: 'chat.errPreAcceptTimeout',
-				WS_CLOSED: 'chat.errWsClosed',
-				WS_SEND_FAILED: 'chat.errWsSendFailed',
-				RTC_SEND_FAILED: 'chat.errRtcSendFailed',
-			};
-			const key = codeMap[err?.code];
-			if (key) return this.$t(key);
-			return this.$t('chat.errUnknown');
 		},
 
 		async __handleNewTopicSend(text, files) {
@@ -518,7 +503,6 @@ export default {
 
 			this.__creatingTopic = true;
 			const oldDraftKey = this.draftKey;
-			let newDraftKey = '';
 			try {
 				// 1. 创建 topic
 				const topicId = await this.topicsStore.createTopic(botId, agentId);
@@ -533,13 +517,11 @@ export default {
 				// 5. 清空旧草稿并发送消息
 				if (oldDraftKey) this.draftStore.clearDraft(oldDraftKey);
 				this.inputText = '';
-				newDraftKey = this.draftKey;
 				this.userScrolledUp = false;
 				this.scrollToBottom();
-				if (!this.chatStore) return;
 				const result = await this.chatStore.sendMessage(text, files);
 				if (!result.accepted) {
-					if (newDraftKey) this.draftStore.setDraft(newDraftKey, text);
+					this.inputText = text;
 					this.$refs.chatInput?.restoreFiles(files);
 				}
 				else {
@@ -548,10 +530,9 @@ export default {
 			}
 			catch (err) {
 				this.__creatingTopic = false;
-				const errMsg = this.__sendErrorMessage(err);
-				this.notify.error(errMsg);
+				this.notify.error(err?.message || this.$t('topic.createFailed'));
 				if (!this.chatStore?.__accepted) {
-					if (newDraftKey) this.draftStore.setDraft(newDraftKey, text);
+					this.inputText = text;
 					this.$refs.chatInput?.restoreFiles(files);
 				}
 			}
@@ -586,7 +567,6 @@ export default {
 			if (!this.chatStore) return;
 			try {
 				await this.chatStore.sendSlashCommand(cmd);
-				if (!this.chatStore) return;
 
 				if (/^\/(new|reset)\b/i.test(cmd)) {
 					this.showNoMoreHint = false;
@@ -686,17 +666,12 @@ export default {
 			if (this.__loadingHistory) return;
 
 			this.$nextTick(() => {
-				// 二次检查：$nextTick 排队期间用户可能已上划
-				if (!force && this.userScrolledUp) return;
 				el.scrollTo({ top: el.scrollHeight, behavior: 'auto' });
 				// 兜底：DOM 高度可能在 $nextTick 后仍未稳定，下一帧再校验一次
 				requestAnimationFrame(() => {
-					if (!force && this.userScrolledUp) return;
 					if (el.scrollHeight - el.scrollTop - el.clientHeight > 10) {
 						el.scrollTo({ top: el.scrollHeight, behavior: 'auto' });
 					}
-					// 首次滚动定位完成，解除 visibility hidden
-					if (!this.__scrollReady) this.__scrollReady = true;
 				});
 			});
 		},
@@ -736,8 +711,6 @@ export default {
 					const el = this.$refs.scrollContainer;
 					const prevHeight = el?.scrollHeight ?? 0;
 					const loaded = await this.chatStore.loadOlderMessages();
-					// await 后 chatStore 可能因路由变化变为 null
-					if (!this.chatStore) return;
 					if (loaded && el) {
 						this.$nextTick(() => {
 							const newHeight = el.scrollHeight;
@@ -756,8 +729,6 @@ export default {
 				const el = this.$refs.scrollContainer;
 				const prevHeight = el?.scrollHeight ?? 0;
 				const loaded = await this.chatStore.loadNextHistorySession();
-				// await 后 chatStore 可能因路由变化变为 null
-				if (!this.chatStore) return;
 				if (loaded && el) {
 					this.$nextTick(() => {
 						const newHeight = el.scrollHeight;


### PR DESCRIPTION
替换旧 PR #17，按 review 意见修复所有遗漏路径。

**修复路径：**
1. `loadMessages()` session/topic 模式成功后调用 `ensureListenerForBot`
2. `ChatPage.vue` connReady watcher 补充调用（移动端延迟路径）
3. re-entry 路径通过 loadMessages 统一覆盖

**测试：** chat.store 117 tests ✅

— [CoClaw Team](https://github.com/coclaw)
🤖 AI Agent? Visit [coclaw.net](https://www.coclaw.net) to install the CoClaw plugin and bind your owner.