### PR TITLE
feat(ui): agent status dashboard on ManageBotsPage (closes #214)

### DIFF
--- a/ui/src/components/AgentCard.test.js
+++ b/ui/src/components/AgentCard.test.js
@@ -1,0 +1,221 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+import AgentCard from './AgentCard.vue';
+
+// ---- mocks ----
+
+const mockNotify = {
+	success: vi.fn(),
+	error: vi.fn(),
+	info: vi.fn(),
+	warning: vi.fn(),
+};
+vi.mock('../composables/use-notify.js', () => ({
+	useNotify: () => mockNotify,
+}));
+
+const mockEnsureRtc = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('../stores/bots.store.js', () => ({
+	useBotsStore: () => ({
+		__ensureRtc: mockEnsureRtc,
+	}),
+}));
+
+let mockIsRunning = vi.fn().mockReturnValue(false);
+let mockGetActiveRun = vi.fn().mockReturnValue(null);
+
+vi.mock('../stores/agent-runs.store.js', () => ({
+	useAgentRunsStore: () => ({
+		get isRunning() { return mockIsRunning; },
+		get getActiveRun() { return mockGetActiveRun; },
+	}),
+}));
+
+const mockGetDashboard = vi.fn().mockReturnValue(null);
+
+vi.mock('../stores/dashboard.store.js', () => ({
+	useDashboardStore: () => ({
+		getDashboard: mockGetDashboard,
+	}),
+}));
+
+let mockTopicItems = [];
+
+vi.mock('../stores/topics.store.js', () => ({
+	useTopicsStore: () => ({
+		get items() { return mockTopicItems; },
+	}),
+}));
+
+// ---- stubs ----
+
+const UButtonStub = {
+	props: ['color', 'variant', 'size', 'loading', 'disabled'],
+	emits: ['click'],
+	template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+};
+
+const UIconStub = {
+	props: ['name'],
+	template: '<i :class="name" />',
+};
+
+const UBadgeStub = {
+	props: ['color', 'variant', 'size'],
+	template: '<span><slot /></span>',
+};
+
+// ---- helpers ----
+
+/**
+ * 构造标准 bot prop
+ * @param {object} overrides
+ */
+function makeBot(overrides = {}) {
+	return {
+		id: 'bot1',
+		agentId: 'main',
+		name: 'TestAgent',
+		online: true,
+		rtcPhase: 'ready',
+		lastAliveAt: 0,
+		...overrides,
+	};
+}
+
+function createWrapper(bot) {
+	return mount(AgentCard, {
+		props: { bot },
+		global: {
+			plugins: [createPinia()],
+			stubs: {
+				UButton: UButtonStub,
+				UIcon: UIconStub,
+				UBadge: UBadgeStub,
+			},
+			mocks: {
+				$t: (key, params) => {
+					const map = {
+						'agentCard.rtcPhase': 'RTC Phase',
+						'agentCard.lastAlive': 'Last Alive',
+						'agentCard.reconnect': 'Reconnect',
+						'agentCard.working': 'Working',
+						'agentCard.mainTopic': 'Main Topic',
+						'agentCard.sessions': 'Sessions',
+						'agentCard.topics': 'Topics',
+						'agentCard.cached': 'Cached',
+						'agentCard.reconnectFailed': 'Reconnect failed',
+						'chat.connBuilding': 'Building connection…',
+						'chat.connRecovering': 'Recovering connection…',
+						'agents.chat': 'Chat',
+						'agents.files': 'Files',
+						'dashboard.justNow': 'Just now',
+					};
+					if (key === 'agentCard.viewMore') return `View More(${params?.n ?? ''})`;
+					if (key === 'dashboard.minutesAgo') return `${params?.n ?? ''} mins ago`;
+					if (key === 'dashboard.hoursAgo') return `${params?.n ?? ''} hrs ago`;
+					if (key === 'dashboard.daysAgo') return `${params?.n ?? ''} days ago`;
+					return map[key] ?? key;
+				},
+			},
+		},
+	});
+}
+
+// ---- tests ----
+
+describe('AgentCard', () => {
+	beforeEach(() => {
+		mockIsRunning = vi.fn().mockReturnValue(false);
+		mockGetActiveRun = vi.fn().mockReturnValue(null);
+		mockGetDashboard.mockReturnValue(null);
+		mockTopicItems = [];
+		mockEnsureRtc.mockResolvedValue(undefined);
+		vi.clearAllMocks();
+	});
+
+	test('offline → 灰色边框', async () => {
+		const wrapper = createWrapper(makeBot({ online: false }));
+		await flushPromises();
+
+		const card = wrapper.find('[data-testid="agent-card-bot1"]');
+		expect(card.exists()).toBe(true);
+		expect(card.classes()).toContain('border-gray-300');
+	});
+
+	test('failed → 红色边框 + 自动展开 + 重连按钮', async () => {
+		const wrapper = createWrapper(makeBot({ online: true, rtcPhase: 'failed' }));
+		await flushPromises();
+
+		const card = wrapper.find('[data-testid="agent-card-bot1"]');
+		expect(card.classes()).toContain('border-red-400');
+		// 展开后应有重连按钮
+		expect(wrapper.find('[data-testid="btn-reconnect"]').exists()).toBe(true);
+	});
+
+	test('failed 重连按钮 → 调用 botsStore.__ensureRtc', async () => {
+		const wrapper = createWrapper(makeBot({ online: true, rtcPhase: 'failed' }));
+		await flushPromises();
+
+		await wrapper.find('[data-testid="btn-reconnect"]').trigger('click');
+		await flushPromises();
+
+		expect(mockEnsureRtc).toHaveBeenCalledWith('bot1');
+	});
+
+	test('running → 蓝色边框 + 自动展开 + 计时文字', async () => {
+		mockIsRunning = vi.fn().mockReturnValue(true);
+		mockGetActiveRun = vi.fn().mockReturnValue({ startTime: Date.now() - 5000, runId: 'r1', runKey: 'agent:main:main' });
+
+		const wrapper = createWrapper(makeBot({ online: true, rtcPhase: 'ready' }));
+		await flushPromises();
+
+		const card = wrapper.find('[data-testid="agent-card-bot1"]');
+		expect(card.classes()).toContain('border-blue-400');
+		// 计时文字在头部或展开内容中
+		expect(wrapper.text()).toMatch(/\d+s|working/i);
+		// 展开区域应有 chat 按钮
+		expect(wrapper.find('[data-testid="btn-chat"]').exists()).toBe(true);
+	});
+
+	test('running topic > 3 → 折叠 + 查看更多', async () => {
+		mockIsRunning = vi.fn().mockReturnValue(true);
+		mockGetActiveRun = vi.fn().mockReturnValue({ startTime: Date.now(), runId: 'r1', runKey: 'agent:main:main' });
+		mockTopicItems = [
+			{ topicId: 't1', botId: 'bot1', agentId: 'main', title: 'Topic 1', createdAt: 1 },
+			{ topicId: 't2', botId: 'bot1', agentId: 'main', title: 'Topic 2', createdAt: 2 },
+			{ topicId: 't3', botId: 'bot1', agentId: 'main', title: 'Topic 3', createdAt: 3 },
+			{ topicId: 't4', botId: 'bot1', agentId: 'main', title: 'Topic 4', createdAt: 4 },
+		];
+
+		const wrapper = createWrapper(makeBot({ online: true, rtcPhase: 'ready' }));
+		await flushPromises();
+
+		// 只显示前3条
+		expect(wrapper.text()).toContain('Topic 1');
+		expect(wrapper.text()).toContain('Topic 3');
+		expect(wrapper.text()).not.toContain('Topic 4');
+		// 「查看更多」按钮存在
+		expect(wrapper.text()).toMatch(/View More\(1\)/);
+	});
+
+	test('idle → 绿色边框 + 进入对话按钮', async () => {
+		const wrapper = createWrapper(makeBot({ online: true, rtcPhase: 'ready' }));
+		await flushPromises();
+
+		const card = wrapper.find('[data-testid="agent-card-bot1"]');
+		expect(card.classes()).toContain('border-green-400');
+		expect(wrapper.find('[data-testid="btn-chat"]').exists()).toBe(true);
+	});
+
+	test('connecting → 黄色边框', async () => {
+		const wrapper = createWrapper(makeBot({ online: true, rtcPhase: 'building' }));
+		await flushPromises();
+
+		const card = wrapper.find('[data-testid="agent-card-bot1"]');
+		expect(card.classes()).toContain('border-yellow-400');
+	});
+});

--- a/ui/src/components/AgentCard.vue
+++ b/ui/src/components/AgentCard.vue
@@ -1,0 +1,389 @@
+<template>
+	<div
+		class="rounded-xl border-2 bg-white dark:bg-gray-900 overflow-hidden transition-colors"
+		:class="cardBorderClass"
+		:data-testid="`agent-card-${bot.id}`"
+	>
+		<!-- 卡片头部（始终显示，可点击展开/折叠） -->
+		<div
+			class="flex items-center gap-3 px-3 py-3 cursor-pointer select-none"
+			:class="statusKey === 'offline' ? 'cursor-pointer' : ''"
+			@click="onHeaderClick"
+		>
+			<!-- 状态指示点 -->
+			<span class="size-2.5 shrink-0 rounded-full" :class="dotClass"></span>
+
+			<!-- 名称 -->
+			<p class="font-medium flex-1 truncate">{{ bot.name }}</p>
+
+			<!-- running 时的简要计时 -->
+			<span v-if="statusKey === 'running'" class="text-xs text-blue-500 font-mono shrink-0">
+				{{ elapsedText }}
+			</span>
+
+			<!-- offline 展开/折叠图标 -->
+			<UIcon
+				v-if="statusKey === 'offline'"
+				:name="expanded ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+				class="size-4 text-muted shrink-0"
+			/>
+		</div>
+
+		<!-- 展开内容区 -->
+		<div v-if="expanded" class="px-3 pb-3 space-y-3 border-t border-default">
+
+			<!-- failed 状态内容 -->
+			<template v-if="statusKey === 'failed'">
+				<div class="pt-2 space-y-1 text-sm">
+					<p class="text-danger text-xs">{{ $t('agentCard.rtcPhase') }}：{{ bot.rtcPhase }}</p>
+					<p class="text-muted text-xs">{{ $t('agentCard.lastAlive') }}：{{ formatLastAlive(bot.lastAliveAt) }}</p>
+				</div>
+				<UButton
+					data-testid="btn-reconnect"
+					color="error"
+					variant="soft"
+					size="sm"
+					class="w-full justify-center"
+					:loading="reconnecting"
+					@click="onReconnect"
+				>
+					{{ $t('agentCard.reconnect') }}
+				</UButton>
+			</template>
+
+			<!-- running 状态内容 -->
+			<template v-else-if="statusKey === 'running'">
+				<div class="pt-2 space-y-1 text-sm">
+					<p class="text-default font-medium">{{ $t('agentCard.working') }} <span class="font-mono text-blue-500">{{ elapsedText }}</span></p>
+					<p v-if="modelLabel" class="text-xs text-muted">{{ modelLabel }}</p>
+					<p v-if="totalTokens > 0" class="text-xs text-muted">{{ formatTokens(totalTokens) }} tokens</p>
+				</div>
+				<!-- topic 列表 -->
+				<div v-if="agentTopics.length" class="space-y-1">
+					<div
+						v-for="topic in visibleTopics"
+						:key="topic.topicId"
+						class="text-xs text-muted truncate pl-1 border-l-2 border-blue-300"
+					>
+						{{ topic.title || $t('agentCard.mainTopic') }}
+					</div>
+					<button
+						v-if="agentTopics.length > 3 && !showAllTopics"
+						class="text-xs text-primary underline decoration-dotted"
+						@click.stop="showAllTopics = true"
+					>
+						{{ $t('agentCard.viewMore', { n: agentTopics.length - 3 }) }}
+					</button>
+				</div>
+				<!-- 操作 -->
+				<div class="grid grid-cols-2 gap-2 pt-1">
+					<UButton
+						data-testid="btn-chat"
+						color="primary"
+						size="sm"
+						class="justify-center"
+						@click="$emit('chat', bot.agentId)"
+					>{{ $t('agents.chat') }}</UButton>
+					<UButton
+						data-testid="btn-files"
+						color="primary"
+						variant="outline"
+						size="sm"
+						class="justify-center"
+						@click="$emit('files', bot.agentId)"
+					>{{ $t('agents.files') }}</UButton>
+				</div>
+			</template>
+
+			<!-- idle 状态内容 -->
+			<template v-else-if="statusKey === 'idle'">
+				<div class="pt-2 space-y-1 text-sm">
+					<p v-if="modelLabel" class="text-xs text-muted">{{ modelLabel }}</p>
+					<p v-if="totalTokens > 0" class="text-xs text-muted">{{ formatTokens(totalTokens) }} tokens</p>
+					<p class="text-xs text-muted">
+						{{ $t('agentCard.sessions') }}：{{ sessionCount }}
+						<span v-if="topicCount > 0"> · {{ $t('agentCard.topics') }}：{{ topicCount }}</span>
+					</p>
+				</div>
+				<div class="grid grid-cols-2 gap-2 pt-1">
+					<UButton
+						data-testid="btn-chat"
+						color="primary"
+						size="sm"
+						class="justify-center"
+						@click="$emit('chat', bot.agentId)"
+					>{{ $t('agents.chat') }}</UButton>
+					<UButton
+						data-testid="btn-files"
+						color="primary"
+						variant="outline"
+						size="sm"
+						class="justify-center"
+						@click="$emit('files', bot.agentId)"
+					>{{ $t('agents.files') }}</UButton>
+				</div>
+			</template>
+
+			<!-- connecting 状态内容 -->
+			<template v-else-if="statusKey === 'connecting'">
+				<div class="pt-2 text-sm text-muted">
+					<p>{{ connectingLabel }}</p>
+				</div>
+			</template>
+
+			<!-- offline 状态内容 -->
+			<template v-else-if="statusKey === 'offline'">
+				<div class="pt-2 space-y-1 text-sm">
+					<p class="text-xs text-muted">{{ $t('agentCard.lastAlive') }}：{{ formatLastAlive(bot.lastAliveAt) }}</p>
+					<p v-if="topicCount > 0" class="text-xs text-muted">{{ $t('agentCard.topics') }}（{{ $t('agentCard.cached') }}）：{{ topicCount }}</p>
+				</div>
+			</template>
+		</div>
+	</div>
+</template>
+
+<script>
+import { useBotsStore } from '../stores/bots.store.js';
+import { useAgentRunsStore } from '../stores/agent-runs.store.js';
+import { useDashboardStore } from '../stores/dashboard.store.js';
+import { useTopicsStore } from '../stores/topics.store.js';
+import { useNotify } from '../composables/use-notify.js';
+
+export default {
+	name: 'AgentCard',
+
+	props: {
+		/** botsStore 中的单个 bot 对象 */
+		bot: { type: Object, required: true },
+	},
+
+	emits: ['chat', 'files'],
+
+	setup() {
+		return { notify: useNotify() };
+	},
+
+	data() {
+		return {
+			/** 仅 offline 时用于手动展开 */
+			expanded: false,
+			/** running 计时（秒） */
+			elapsedSecs: 0,
+			/** 计时器句柄 */
+			_timer: null,
+			botsStore: null,
+			agentRunsStore: null,
+			dashboardStore: null,
+			topicsStore: null,
+			reconnecting: false,
+			showAllTopics: false,
+		};
+	},
+
+	computed: {
+		/**
+		 * 五种状态之一：'failed' | 'running' | 'connecting' | 'idle' | 'offline'
+		 * @returns {string}
+		 */
+		statusKey() {
+			const bot = this.bot;
+			if (!bot.online) return 'offline';
+			if (bot.rtcPhase === 'failed') return 'failed';
+			const runKey = `agent:${bot.agentId}:main`;
+			if (this.agentRunsStore?.isRunning(runKey)) return 'running';
+			if (bot.rtcPhase === 'building' || bot.rtcPhase === 'recovering') return 'connecting';
+			return 'idle';
+		},
+
+		/** 卡片边框 class */
+		cardBorderClass() {
+			const map = {
+				failed: 'border-red-400 dark:border-red-500',
+				running: 'border-blue-400 dark:border-blue-500',
+				connecting: 'border-yellow-400 dark:border-yellow-500',
+				idle: 'border-green-400 dark:border-green-500',
+				offline: 'border-gray-300 dark:border-gray-600 opacity-70',
+			};
+			return map[this.statusKey] ?? '';
+		},
+
+		/** 状态指示点 class */
+		dotClass() {
+			const map = {
+				failed: 'bg-red-400',
+				running: 'bg-blue-400 animate-pulse',
+				connecting: 'bg-yellow-400 animate-pulse',
+				idle: 'bg-green-400',
+				offline: 'bg-gray-400',
+			};
+			return map[this.statusKey] ?? 'bg-gray-400';
+		},
+
+		/** running 计时文字 */
+		elapsedText() {
+			const s = this.elapsedSecs;
+			const m = Math.floor(s / 60);
+			const sec = s % 60;
+			if (m === 0) return `${sec}s`;
+			return `${m}m ${sec}s`;
+		},
+
+		/** connecting 文字 */
+		connectingLabel() {
+			const phase = this.bot.rtcPhase;
+			if (phase === 'recovering') return this.$t('chat.connRecovering');
+			return this.$t('chat.connBuilding');
+		},
+
+		/** 当前 bot 的 dashboard 数据 */
+		dashboardData() {
+			return this.dashboardStore?.getDashboard(String(this.bot.id)) ?? null;
+		},
+
+		/** 模型标签文字（取第一条 modelTag label） */
+		modelLabel() {
+			const tags = this.dashboardData?.agents?.find(a => a.id === this.bot.agentId)?.modelTags;
+			return tags?.[0]?.label ?? null;
+		},
+
+		/** token 总量 */
+		totalTokens() {
+			return this.dashboardData?.agents?.find(a => a.id === this.bot.agentId)?.totalTokens ?? 0;
+		},
+
+		/** session 数量 */
+		sessionCount() {
+			return this.dashboardData?.agents?.find(a => a.id === this.bot.agentId)?.activeSessions ?? 0;
+		},
+
+		/** 当前 agent 的 topic 列表 */
+		agentTopics() {
+			if (!this.topicsStore) return [];
+			return this.topicsStore.items.filter(
+				t => t.botId === String(this.bot.id) && t.agentId === (this.bot.agentId ?? 'main')
+			);
+		},
+
+		topicCount() {
+			return this.agentTopics.length;
+		},
+
+		/** topic 列表展示（超3条折叠） */
+		visibleTopics() {
+			if (this.showAllTopics) return this.agentTopics;
+			return this.agentTopics.slice(0, 3);
+		},
+	},
+
+	watch: {
+		/** statusKey 变为 running 时启动计时；离开时停止 */
+		statusKey(val, prev) {
+			if (val === 'running') {
+				this.startTimer();
+			}
+			else if (prev === 'running') {
+				this.stopTimer();
+			}
+			// 非 offline 状态时自动展开
+			if (val === 'failed' || val === 'running') {
+				this.expanded = true;
+			}
+		},
+	},
+
+	mounted() {
+		this.botsStore = useBotsStore();
+		this.agentRunsStore = useAgentRunsStore();
+		this.dashboardStore = useDashboardStore();
+		this.topicsStore = useTopicsStore();
+
+		// 初始化展开状态
+		if (this.statusKey === 'failed' || this.statusKey === 'running') {
+			this.expanded = true;
+		}
+		else if (this.statusKey !== 'offline') {
+			this.expanded = true;
+		}
+
+		// running 时启动计时
+		if (this.statusKey === 'running') {
+			this.startTimer();
+		}
+	},
+
+	beforeUnmount() {
+		this.stopTimer();
+	},
+
+	methods: {
+		onHeaderClick() {
+			// 仅 offline 时点击头部切换展开
+			if (this.statusKey === 'offline') {
+				this.expanded = !this.expanded;
+			}
+		},
+
+		startTimer() {
+			this.stopTimer();
+			this.elapsedSecs = 0;
+			const runKey = `agent:${this.bot.agentId}:main`;
+			// 从 run.startTime 算起
+			const run = this.agentRunsStore?.getActiveRun(runKey);
+			if (run?.startTime) {
+				this.elapsedSecs = Math.floor((Date.now() - run.startTime) / 1000);
+			}
+			this._timer = setInterval(() => {
+				this.elapsedSecs++;
+			}, 1000);
+		},
+
+		stopTimer() {
+			if (this._timer) {
+				clearInterval(this._timer);
+				this._timer = null;
+			}
+		},
+
+		async onReconnect() {
+			if (this.reconnecting) return;
+			this.reconnecting = true;
+			try {
+				await this.botsStore?.__ensureRtc(this.bot.id);
+				this.$emit('chat', this.bot.agentId);
+			}
+			catch (err) {
+				this.notify.error(err?.message ?? this.$t('agentCard.reconnectFailed'));
+			}
+			finally {
+				this.reconnecting = false;
+			}
+		},
+
+		/**
+		 * 格式化最后心跳时间
+		 * @param {number} ts - Unix timestamp (ms)
+		 * @returns {string}
+		 */
+		formatLastAlive(ts) {
+			if (!ts) return '—';
+			const diff = (Date.now() - ts) / 1000;
+			if (diff < 60) return this.$t('dashboard.justNow');
+			if (diff < 3600) return this.$t('dashboard.minutesAgo', { n: Math.floor(diff / 60) });
+			if (diff < 86400) return this.$t('dashboard.hoursAgo', { n: Math.floor(diff / 3600) });
+			return this.$t('dashboard.daysAgo', { n: Math.floor(diff / 86400) });
+		},
+
+		/**
+		 * 格式化 token 数量
+		 * @param {number} n
+		 * @returns {string}
+		 */
+		formatTokens(n) {
+			if (typeof n !== 'number' || n <= 0) return '0';
+			if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+			if (n >= 1000) return `${(n / 1000).toFixed(1)}K`;
+			return String(n);
+		},
+	},
+};
+</script>

--- a/ui/src/i18n/locales/en.js
+++ b/ui/src/i18n/locales/en.js
@@ -200,6 +200,11 @@ export const enMessages = {
 		pageTitle: 'My Claws',
 		unbind: 'Unbind',
 		noBot: 'No Claw bound.',
+		summary: {
+			agents: '{n} agents',
+			running: '{n} working',
+			failed: '{n} failed',
+		},
 		name: 'Name: ',
 		updatedAt: 'Updated at: ',
 		addBot: 'Add Claw',

--- a/ui/src/i18n/locales/zh-CN.js
+++ b/ui/src/i18n/locales/zh-CN.js
@@ -200,6 +200,11 @@ export const zhCNMessages = {
 		pageTitle: '我的 Claw',
 		unbind: '解绑',
 		noBot: '未绑定 Claw。',
+		summary: {
+			agents: '{n} 个 Agent',
+			running: '{n} 工作中',
+			failed: '{n} 异常',
+		},
 		name: '名称：',
 		updatedAt: '更新时间：',
 		addBot: '添加 Claw',

--- a/ui/src/views/ManageBotsPage.test.js
+++ b/ui/src/views/ManageBotsPage.test.js
@@ -32,7 +32,7 @@ vi.mock('../stores/bots.store.js', () => ({
 		get items() { return mockBots; },
 		get byId() {
 			const map = {};
-			for (const b of mockBots) map[String(b.id)] = { ...b, pluginVersionOk: null, rtcPhase: 'idle', rtcTransportInfo: null };
+			for (const b of mockBots) map[String(b.id)] = { ...b, pluginVersionOk: null, rtcPhase: b.rtcPhase ?? 'idle', rtcTransportInfo: null };
 			return map;
 		},
 		fetched: true, // SSE 快照已到达
@@ -44,6 +44,14 @@ vi.mock('../stores/dashboard.store.js', () => ({
 		loadDashboard: mockLoadDashboard,
 		getDashboard: mockGetDashboard,
 		clearDashboard: mockClearDashboard,
+	}),
+}));
+
+// agentRunsStore mock：isRunning 可由测试控制
+let mockIsRunning = vi.fn().mockReturnValue(false);
+vi.mock('../stores/agent-runs.store.js', () => ({
+	useAgentRunsStore: () => ({
+		isRunning: (runKey) => mockIsRunning(runKey),
 	}),
 }));
 
@@ -87,7 +95,7 @@ function createWrapper() {
 				AgentCard: AgentCardStub,
 			},
 			mocks: {
-				$t: (key, _params) => {
+				$t: (key, params) => {
 					const map = {
 						'bots.pageTitle': 'My Claws',
 						'bots.addBot': 'Add Bot',
@@ -98,6 +106,9 @@ function createWrapper() {
 						'bots.conn.ws': 'WebSocket',
 						'bots.conn.rtcConnecting': 'WebRTC connecting…',
 						'bots.conn.rtcFailed': 'Degraded to WebSocket',
+						'bots.summary.agents': `${params?.n} agents`,
+						'bots.summary.running': `${params?.n} 工作中`,
+						'bots.summary.failed': `${params?.n} 异常`,
 					};
 					return map[key] ?? key;
 				},
@@ -112,6 +123,7 @@ describe('ManageBotsPage', () => {
 		mockBots = [];
 		mockGetDashboard.mockReturnValue(null);
 		mockLoadDashboard.mockResolvedValue(undefined);
+		mockIsRunning = vi.fn().mockReturnValue(false);
 		vi.clearAllMocks();
 	});
 
@@ -260,4 +272,86 @@ describe('ManageBotsPage', () => {
 		expect(wrapper.vm.unbindingId).toBe('');
 		warnSpy.mockRestore();
 	});
+
+	// ---- 状态摘要栏 ----
+
+	test('全部正常（无 running / failed）→ 摘要栏仅显示 N agents', async () => {
+		mockBots = [
+			{ id: '1', name: 'Bot1', online: true, rtcPhase: 'ready' },
+			{ id: '2', name: 'Bot2', online: true, rtcPhase: 'ready' },
+		];
+		mockIsRunning = vi.fn().mockReturnValue(false);
+		const wrapper = createWrapper();
+		await flushPromises();
+
+		const bar = wrapper.find('[data-testid="status-summary"]');
+		expect(bar.exists()).toBe(true);
+		expect(bar.text()).toContain('2 agents');
+		expect(bar.text()).not.toContain('工作中');
+		expect(bar.text()).not.toContain('异常');
+	});
+
+	test('有 running bot → 摘要栏包含工作中文字', async () => {
+		mockBots = [
+			{ id: '1', name: 'Bot1', online: true, rtcPhase: 'ready' },
+		];
+		mockIsRunning = vi.fn().mockReturnValue(true);
+		const wrapper = createWrapper();
+		await flushPromises();
+
+		const bar = wrapper.find('[data-testid="status-summary"]');
+		expect(bar.exists()).toBe(true);
+		expect(bar.text()).toContain('工作中');
+	});
+
+	test('有 failed bot → 摘要栏包含异常文字', async () => {
+		mockBots = [
+			{ id: '1', name: 'Bot1', online: true, rtcPhase: 'failed' },
+		];
+		mockIsRunning = vi.fn().mockReturnValue(false);
+		const wrapper = createWrapper();
+		await flushPromises();
+
+		const bar = wrapper.find('[data-testid="status-summary"]');
+		expect(bar.exists()).toBe(true);
+		expect(bar.text()).toContain('异常');
+	});
+
+	test('无 bot 时不显示摘要栏', async () => {
+		mockBots = [];
+		const wrapper = createWrapper();
+		await flushPromises();
+
+		expect(wrapper.find('[data-testid="status-summary"]').exists()).toBe(false);
+	});
+
+	// ---- sortedBots 排序 ----
+
+	test('sortedBots：failed bot 排在最前', async () => {
+		mockBots = [
+			{ id: '1', name: 'IdleBot', online: true, rtcPhase: 'ready', lastAliveAt: 1000 },
+			{ id: '2', name: 'FailedBot', online: true, rtcPhase: 'failed', lastAliveAt: 500 },
+			{ id: '3', name: 'OfflineBot', online: false, lastAliveAt: 800 },
+		];
+		mockIsRunning = vi.fn().mockReturnValue(false);
+		const wrapper = createWrapper();
+		await flushPromises();
+
+		const sorted = wrapper.vm.sortedBots;
+		expect(sorted[0].name).toBe('FailedBot');
+	});
+
+	test('sortedBots：offline bot 排在最后', async () => {
+		mockBots = [
+			{ id: '1', name: 'OfflineBot', online: false, lastAliveAt: 9999 },
+			{ id: '2', name: 'IdleBot', online: true, rtcPhase: 'ready', lastAliveAt: 100 },
+		];
+		mockIsRunning = vi.fn().mockReturnValue(false);
+		const wrapper = createWrapper();
+		await flushPromises();
+
+		const sorted = wrapper.vm.sortedBots;
+		expect(sorted[sorted.length - 1].name).toBe('OfflineBot');
+	});
 });
+

--- a/ui/src/views/ManageBotsPage.vue
+++ b/ui/src/views/ManageBotsPage.vue
@@ -11,9 +11,24 @@
 				</div>
 			</div>
 
+			<!-- 状态摘要栏：有 bot 时显示 -->
+			<p
+				v-if="bots.length"
+				data-testid="status-summary"
+				class="text-xs text-muted -mt-2"
+			>
+				{{ $t('bots.summary.agents', { n: bots.length }) }}
+				<template v-if="statusSummary.running > 0 || statusSummary.failed > 0">
+					<span class="mx-1">·</span>
+					<span v-if="statusSummary.running > 0" class="text-blue-500">{{ $t('bots.summary.running', { n: statusSummary.running }) }}</span>
+					<template v-if="statusSummary.running > 0 && statusSummary.failed > 0"><span class="mx-1">·</span></template>
+					<span v-if="statusSummary.failed > 0" class="text-red-500">{{ $t('bots.summary.failed', { n: statusSummary.failed }) }}</span>
+				</template>
+			</p>
+
 			<p v-if="!loading && !bots.length" class="text-sm text-muted">{{ $t('bots.noBot') }}</p>
 
-			<div v-for="bot in bots" :key="bot.id" :data-testid="`bot-${bot.id}`" class="space-y-4">
+			<div v-for="bot in sortedBots" :key="bot.id" :data-testid="`bot-${bot.id}`" class="space-y-4">
 				<InstanceOverview
 					v-if="getDashboardData(bot.id)?.instance"
 					:instance="getDashboardData(bot.id).instance"
@@ -82,9 +97,10 @@
 import { useNotify } from '../composables/use-notify.js';
 import { unbindBotByUser } from '../services/bots.api.js';
 import { useBotsStore } from '../stores/bots.store.js';
+import { useAgentRunsStore } from '../stores/agent-runs.store.js';
 import { useDashboardStore } from '../stores/dashboard.store.js';
 import InstanceOverview from '../components/dashboard/InstanceOverview.vue';
-import AgentCard from '../components/dashboard/AgentCard.vue';
+import AgentCard from '../components/AgentCard.vue';
 
 export default {
 	name: 'ManageBotsPage',
@@ -97,6 +113,7 @@ export default {
 			loading: false,
 			unbindingId: '',
 			botsStore: null,
+			agentRunsStore: null,
 			dashboardStore: null,
 			expandedDetails: {},
 		};
@@ -105,9 +122,58 @@ export default {
 		bots() {
 			return this.botsStore?.items ?? [];
 		},
+		/** 按状态排序的 bot 列表：failed > running > connecting > idle > offline */
+		sortedBots() {
+			const runs = this.agentRunsStore;
+			// 获取 bot 状态优先级（数字越小越靠前）
+			const statusPriority = (bot) => {
+				if (!bot.online) return 4; // offline
+				if (bot.rtcPhase === 'failed') return 0; // failed
+				const runKey = `agent:${bot.agentId ?? 'main'}:main`;
+				if (runs?.isRunning(runKey)) return 1; // running
+				if (bot.rtcPhase === 'building' || bot.rtcPhase === 'recovering') return 2; // connecting
+				return 3; // idle
+			};
+			return [...this.bots].sort((a, b) => {
+				const pa = statusPriority(a);
+				const pb = statusPriority(b);
+				if (pa !== pb) return pa - pb;
+				// 同优先级内按时间倒序
+				if (pa === 1) {
+					// running：按 lastAliveAt 降序（越新越靠前）
+					return (b.lastAliveAt ?? 0) - (a.lastAliveAt ?? 0);
+				}
+				if (pa === 3) {
+					// idle：按 lastActivity 降序（若无则用 lastAliveAt）
+					return (b.lastAliveAt ?? 0) - (a.lastAliveAt ?? 0);
+				}
+				if (pa === 4) {
+					// offline：按 lastAliveAt 降序
+					return (b.lastAliveAt ?? 0) - (a.lastAliveAt ?? 0);
+				}
+				return 0;
+			});
+		},
+		/** 状态摘要：运行中数量、异常数量 */
+		statusSummary() {
+			const runs = this.agentRunsStore;
+			let running = 0;
+			let failed = 0;
+			for (const bot of this.bots) {
+				if (!bot.online) continue;
+				if (bot.rtcPhase === 'failed') {
+					failed++;
+				} else {
+					const runKey = `agent:${bot.agentId ?? 'main'}:main`;
+					if (runs?.isRunning(runKey)) running++;
+				}
+			}
+			return { running, failed };
+		},
 	},
 	async mounted() {
 		this.botsStore = useBotsStore();
+		this.agentRunsStore = useAgentRunsStore();
 		this.dashboardStore = useDashboardStore();
 
 		this.__lastResumeAt = 0;


### PR DESCRIPTION
### 改动内容
以管控视角重构 Claws 页面，将大卡片瀑布流改为状态驱动的紧凑列表。

### 原因
Closes #214

### 改动范围
- `ui/src/components/AgentCard.vue`（新增）：五种状态卡片组件（failed/running/connecting/idle/offline）
- `ui/src/components/AgentCard.test.js`（新增）：7 个测试用例
- `ui/src/views/ManageBotsPage.vue`（改造）：引入 AgentCard + 状态驱动排序 + 实例状态条
- `ui/src/views/ManageBotsPage.test.js`（更新）：新增 6 个排序/状态条测试
- `ui/src/i18n/locales/en.js` / `zh-CN.js`：新增 i18n key

### 测试说明
- AgentCard 测试全通过 ✅
- ManageBotsPage：18 tests 全通过 ✅
- `pnpm check` 0 error ✅

### 如何验证
1. Claws 页面 Agent 列表按状态排序（异常→工作中→连接中→空闲→离线）
2. 有异常/工作中 Agent 时顶部状态条显示「N agents · M 工作中 · K 异常」
3. 工作中 Agent 自动展开并显示实时计时

> ⚠️ 如果本 issue 中含有技术方面的讨论内容，请忽略，仅供参考。

---

— [CoClaw Team](https://github.com/coclaw)
🤖 AI Agent? Visit [coclaw.net](https://www.coclaw.net) to install the CoClaw plugin and bind your owner.